### PR TITLE
Fix duplicate session creation and redirect on sign in 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module MyEtm
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::ActiveRecordStore, key: "_idp_session"
+
     config.to_prepare do
       Doorkeeper::AuthorizationsController.layout 'login'
       Doorkeeper::AuthorizedApplicationsController.layout 'identity'

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,5 @@
-MyEtm::Application.config.session_store :active_record_store, key: "_idp_session", domain: :all, tld_length: 2
+MyEtm::Application.config.session_store :active_record_store,
+                                        key: "_idp_session",
+                                        domain: '.energytransitionmodel.com',
+                                        secure: Rails.env.production?,
+                                        same_site: :none


### PR DESCRIPTION
I think the 422 on sign up / login is due to two idp_session tokens being generated by MyETM. Based on my understanding, explicitly setting the domain will set one session across the whole domain, which should resolve the duplication issue. This kind of needs to be tested on the server, as it works locally either way.

Additional detail: I thought tld_length: 2 would already scope the domain to the higher level, but apparently that didn't completely work.

Secondly, I think the redirect was due to a CSRF error caused by the sessions not persisting properly because the app wasn't properly configured to use them (and cookies) in application.rb.