### PR TITLE
Versions as database entities

### DIFF
--- a/app/components/collections/row/component.html.erb
+++ b/app/components/collections/row/component.html.erb
@@ -22,7 +22,7 @@
         <% end %>
       </div>
     </div>
-    <span class="text-midnight-400">  <%= @collection.version %></span>
+    <span class="text-midnight-400">  <%= @collection.version.tag %></span>
   </div>
   <span class="text-midnight-400 mx-auto text-sm mt-3">
     Last updated <%= time_ago_in_words(@collection.updated_at) %> ago

--- a/app/components/collections/scenario_picker/component.html.erb
+++ b/app/components/collections/scenario_picker/component.html.erb
@@ -10,7 +10,7 @@
     hover:bg-midnight-600
     hover:cursor-pointer
     "
-    data-version= <%=scenario.version%>
+    data-version= <%=scenario.version.tag%>
     data-collections-target= "scenario"
     data-controller="select-inner-contents"
     data-action="click->select-inner-contents#select"

--- a/app/components/saved_scenarios/row/component.html.erb
+++ b/app/components/saved_scenarios/row/component.html.erb
@@ -8,7 +8,7 @@
         <span><%= @saved_scenario.end_year %></span>
       </div>
     </div>
-    <span class="text-midnight-400"> #<%= @saved_scenario.version %></span>
+    <span class="text-midnight-400"> #<%= @saved_scenario.version.tag %></span>
   </div>
   <span class="text-midnight-400 mx-auto text-sm mt-3"> Last updated <%= time_ago_in_words(@saved_scenario.updated_at) %> ago </span>
   <div class="ml-auto mr-0 mt-3 text-midnight-400">

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -40,7 +40,7 @@ module Api
       private
 
       def collection_params
-        params.require(:collection).permit(:title, :version, saved_scenario_ids: [])
+        params.require(:collection).permit(:title, saved_scenario_ids: [])
       end
 
       def create_transition_params

--- a/app/controllers/api/v1/featured_scenarios_controller.rb
+++ b/app/controllers/api/v1/featured_scenarios_controller.rb
@@ -33,7 +33,7 @@ module Api
       def featured_scenarios
         if version.present?
           FeaturedScenario.joins(:saved_scenario)
-            .where(saved_scenario: { version: version['version'] })
+            .where(saved_scenario: { version: Version.find_by(tag: version['version']) })
         else
           FeaturedScenario.all
         end

--- a/app/controllers/api/v1/saved_scenarios_controller.rb
+++ b/app/controllers/api/v1/saved_scenarios_controller.rb
@@ -1,11 +1,7 @@
 module Api
   module V1
     class SavedScenariosController < BaseController
-      load_and_authorize_resource(class: SavedScenario, only: %i[index show update destroy])
-
-      before_action only: %i[create] do
-        authorize!(:create, SavedScenario)
-      end
+      load_and_authorize_resource(class: SavedScenario, only: %i[index create show update destroy])
 
       # GET /saved_scenarios or /saved_scenarios.json
       def index

--- a/app/controllers/api/v1/saved_scenarios_controller.rb
+++ b/app/controllers/api/v1/saved_scenarios_controller.rb
@@ -79,7 +79,7 @@ module Api
         if Version.tags.include?(saved_scenario_params[:version].to_s)
           saved_scenario_params[:version]
         else
-          Version::DEFAULT_TAG
+          Version.default.tag
         end
       end
     end

--- a/app/controllers/api/v1/saved_scenarios_controller.rb
+++ b/app/controllers/api/v1/saved_scenarios_controller.rb
@@ -1,7 +1,11 @@
 module Api
   module V1
     class SavedScenariosController < BaseController
-      load_and_authorize_resource(class: SavedScenario, only: %i[index show create update destroy])
+      load_and_authorize_resource(class: SavedScenario, only: %i[index show update destroy])
+
+      before_action only: %i[create] do
+        authorize!(:create, SavedScenario)
+      end
 
       # GET /saved_scenarios or /saved_scenarios.json
       def index
@@ -70,17 +74,13 @@ module Api
       def engine_client
         MyEtm::Auth.engine_client(
           current_user,
-          active_version_tag,
+          active_version,
           scopes: doorkeeper_token ? doorkeeper_token.scopes : []
         )
       end
 
-      def active_version_tag
-        if Version.tags.include?(saved_scenario_params[:version].to_s)
-          saved_scenario_params[:version]
-        else
-          Version.default.tag
-        end
+      def active_version
+        Version.find_by(tag: saved_scenario_params[:version]) || Version.default
       end
     end
   end

--- a/app/controllers/api/v1/versions_controller.rb
+++ b/app/controllers/api/v1/versions_controller.rb
@@ -4,7 +4,11 @@ module Api
       skip_before_action :authenticate_request!
 
       def index
-        render json: { versions: Version.as_json }, status: :ok
+        versions = Version.all
+        versions = versions.where(tag: params[:tag]) if params[:tag].present?
+        versions = versions.order(created_at: :desc) if params[:sort] == 'desc'
+
+        render json: { versions: versions.as_json }, status: :ok
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < ActionController::Base
   end
 
   def active_version_tag
-    session[:active_version_tag] || Version::DEFAULT_TAG
+    session[:active_version_tag] || Version.default.tag
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,8 +76,8 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def engine_client(version_tag)
-    MyEtm::Auth.engine_client(current_user, version_tag)
+  def engine_client(version)
+    MyEtm::Auth.engine_client(current_user, version)
   end
 
   # Internal: Renders a 404 page.

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -167,10 +167,10 @@ class CollectionsController < ApplicationController
   end
 
   def ensure_valid_config
-    return if Settings.collections_url
+    return if Settings.collections.uri
 
     redirect_to root_path,
-      notice: 'Missing collections_url setting in config.yml'
+      notice: 'Missing collections.uri setting in config.yml'
   end
 
   def create_collection_params

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -75,7 +75,7 @@ class CollectionsController < ApplicationController
   # POST /collections/create_transition
   def create_transition
     result = CreateInterpolatedCollection.call(
-      engine_client(create_transition_params[:version]),
+      engine_client(Version.find_by(tag: create_transition_params[:version])),
       current_user.saved_scenarios.find(create_transition_params[:saved_scenario_ids]),
       current_user
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHelper
       myetm_url: root_url.chomp("/"),
       etengine_url: etengine_url,
       etmodel_url: Settings.etmodel.uri || "http://YOUR_ETMODEL_URL",
-      collections_url: Settings.collections_url || "http://YOUR_COLLECTIONS_URL",
+      collections_url: Settings.collections.uri || "http://YOUR_COLLECTIONS_URL",
       etengine_uid: Doorkeeper::Application.find_by(uri: etengine_url)&.uid || "YOUR_ETEngine_ID"
     ))
   end

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -5,8 +5,8 @@ module CollectionsHelper
   # Collections.
   #
   # Returns a string.
-  def myc_url(collection)
-    "#{Settings.collections_url}/#{collection.redirect_slug}?" \
+  def collection_url(collection)
+    "#{collection.version.collection_url}/#{collection.redirect_slug}?" \
       "locale=#{I18n.locale}&" \
       "title=#{ERB::Util.url_encode(collection.title)}"
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -12,6 +12,7 @@ class Collection < ApplicationRecord
   FILTER_PARAMS = %i[title interpolated plain].freeze
 
   belongs_to :user
+  belongs_to :version
 
   has_many :scenarios,
     class_name: 'CollectionScenario',
@@ -41,6 +42,7 @@ class Collection < ApplicationRecord
       end_year: scenario.end_year,
       title: scenario.title,
       interpolation: true,
+      version: scenario.version,
       saved_scenario_ids: [ scenario.id ]
     }.merge(attrs))
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -89,7 +89,7 @@ class Collection < ApplicationRecord
   #
   # For example:
   #
-  #   redirect_to(myc_url(myc.redirect_slug))
+  #   redirect_to(collection_url(myc.redirect_slug))
   #
   # Returns an array.
   def redirect_slug

--- a/app/models/featured_scenario.rb
+++ b/app/models/featured_scenario.rb
@@ -88,7 +88,7 @@ class FeaturedScenario < ApplicationRecord
 
   def as_json(options = {})
     super.merge(
-      version: version,
+      version: version.tag,
       end_year: end_year,
       author: owner&.user&.name || "No author"
     )

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -3,7 +3,7 @@
 class OAuthApplication < ApplicationRecord
   include Doorkeeper::Orm::ActiveRecord::Mixins::Application
 
+  belongs_to :version
   has_many :staff_applications, foreign_key: :application_id, dependent: :destroy
-
   validates :uri, presence: true, 'doorkeeper/redirect_uri': true
 end

--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -123,4 +123,13 @@ class SavedScenario < ApplicationRecord
 
     saved_scenarios
   end
+
+  # Allow version to be set by either tag or Version object
+  def version=(version_or_tag)
+    if version_or_tag.is_a?(Version)
+      self.version_id = version_or_tag.id
+    else
+      self.version_id = Version.find_by(tag: version_or_tag)&.id
+    end
+  end
 end

--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -19,6 +19,7 @@ class SavedScenario < ApplicationRecord
   has_one :featured_scenario, dependent: :destroy
   has_many :saved_scenario_users, dependent: :destroy
   has_many :users, through: :saved_scenario_users
+  belongs_to :version
 
   has_rich_text :description
 
@@ -26,9 +27,6 @@ class SavedScenario < ApplicationRecord
   validates :title,       presence: true
   validates :end_year,    presence: true
   validates :area_code,   presence: true
-  validates :version, presence: true, inclusion: {
-    in: Version.tags, message: "Version should be one of #{Version.tags}"
-  }
 
   serialize :scenario_id_history, coder: YAML, type: Array
 
@@ -73,6 +71,11 @@ class SavedScenario < ApplicationRecord
   def scenario=(x)
     @scenario = x
     self.scenario_id = x.id unless x.nil?
+  end
+
+  def as_json(*)
+    json = super.except(:version_id)
+    json.merge("version" => version.tag)
   end
 
   # TODO: Determine if necessary

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,13 +1,16 @@
 class Version < ApplicationRecord
+
+  has_many :oauth_applications, dependent: :nullify
+
+  validates :tag, presence: true, uniqueness: true
+  validates :url_prefix, presence: true, unless: -> { tag == "latest" }
+
   URL = "energytransitionmodel.com".freeze
   LOCAL_URLS = {
     "collections" => Settings.collections_url,
     "model" => Settings.etmodel.uri,
     "engine" => Settings.etengine.uri
   }.freeze
-
-  validates :tag, presence: true, uniqueness: true
-  validates :url_prefix, presence: true, unless: -> { tag == "latest" }
 
   # Fetch all version tags
   def self.tags

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,13 +1,14 @@
 class Version < ApplicationRecord
-
   has_many :oauth_applications, dependent: :nullify
+  has_many :saved_scenarios
+  has_many :collections
 
   validates :tag, presence: true, uniqueness: true
   validates :url_prefix, presence: true, unless: -> { tag == "latest" }
 
   URL = "energytransitionmodel.com".freeze
   LOCAL_URLS = {
-    "collections" => Settings.collections_url,
+    "collections" => Settings.collections.uri,
     "model" => Settings.etmodel.uri,
     "engine" => Settings.etengine.uri
   }.freeze
@@ -37,11 +38,12 @@ class Version < ApplicationRecord
 
   # Serialize versions for API responses
   def as_json(*)
-    super.merge(
+    {
+      tag: tag,
       model_url: model_url,
       engine_url: engine_url,
       collections_url: collections_url
-    )
+    }
   end
 
   private

--- a/app/services/create_collection.rb
+++ b/app/services/create_collection.rb
@@ -8,7 +8,7 @@ class CreateCollection
   def call
     collection = user.collections.build(
       title: collection_title,
-      version: settings[:version],
+      version: version,
       interpolation: false
     )
 
@@ -31,5 +31,9 @@ class CreateCollection
 
   def scenario_ids
     settings[:saved_scenario_ids].uniq.reject(&:blank?)
+  end
+
+  def version
+    SavedScenario.find(scenario_ids.first).version
   end
 end

--- a/app/services/saved_scenario/create.rb
+++ b/app/services/saved_scenario/create.rb
@@ -19,6 +19,9 @@ class SavedScenario::Create
   def call
     return failure unless saved_scenario.valid?
 
+    # Sometimes we have to explicitly set the user again
+    saved_scenario.user = user
+
     protect
 
     saved_scenario.save

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <div class="w-min mb-5">
-  <%= render(HovercardWithVersion::Component.new(version: @collection.version))%>
+  <%= render(HovercardWithVersion::Component.new(version: @collection.version.tag))%>
 </div>
 
 <div class="pt-5 border-t border-solid border-gray-200">

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -2,7 +2,7 @@
 <%= render(partial: "collections/show/block_right_menu", locals: { collection: @collection })%>
 
 <%= render(Collections::Info::Component.new(
-    path: myc_url(@collection),
+    path: collection_url(@collection),
     button_title: t('collections.open'),
     collection: @collection,
     time: time_ago_in_words(@collection.created_at))

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -1,5 +1,5 @@
 .sidebar.fixed.top-0.bottom-0.overflow-y-auto.bg-midnight-300{class: 'lg:left-0 w-[300px]'}
-  %a.logo.p-5.mb-3.inline-block.w-full.text-midnight-800{href: Version.model_url(active_version_tag)}
+  %a.logo.p-5.mb-3.inline-block.w-full.text-midnight-800{href: Version.find_by(tag: active_version_tag).model_url}
     = image_tag 'header/logo-round.png', class: 'h-8 inline mb-1 mr-2 hover:animate-spin'
     %span Energy Transition Model
 

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :menu_title, @saved_scenario.localized_title(I18n.locale)
 = render(partial: "block_right_menu", locals: { saved_scenario: @saved_scenario })
 
-= render(SavedScenarios::Info::Component.new(path: "#{Version.model_url(@saved_scenario.version)}/saved_scenarios/#{@saved_scenario.id}/load", button_title: t('saved_scenario.open'), saved_scenario: @saved_scenario, time: time_ago_in_words(@saved_scenario.updated_at)))
+= render(SavedScenarios::Info::Component.new(path: "#{Version.find_by(tag: @saved_scenario.version).model_url}/saved_scenarios/#{@saved_scenario.id}/load", button_title: t('saved_scenario.open'), saved_scenario: @saved_scenario, time: time_ago_in_words(@saved_scenario.updated_at)))
 
 - if flash[:undo_params]
   = render(NoticeBanner::Component.new(path: flash[:undo_params], text: notice_message, button_text: "#{t('undo')}?"))

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :menu_title, @saved_scenario.localized_title(I18n.locale)
 = render(partial: "block_right_menu", locals: { saved_scenario: @saved_scenario })
 
-= render(SavedScenarios::Info::Component.new(path: "#{Version.find_by(tag: @saved_scenario.version).model_url}/saved_scenarios/#{@saved_scenario.id}/load", button_title: t('saved_scenario.open'), saved_scenario: @saved_scenario, time: time_ago_in_words(@saved_scenario.updated_at)))
+= render(SavedScenarios::Info::Component.new(path: "#{@saved_scenario.version.model_url}/saved_scenarios/#{@saved_scenario.id}/load", button_title: t('saved_scenario.open'), saved_scenario: @saved_scenario, time: time_ago_in_words(@saved_scenario.updated_at)))
 
 - if flash[:undo_params]
   = render(NoticeBanner::Component.new(path: flash[:undo_params], text: notice_message, button_text: "#{t('undo')}?"))
@@ -10,7 +10,7 @@
   = render(NoticeBanner::TrashComponent.new(text: t('trash.notice', deleted_after: SavedScenario::AUTO_DELETES_AFTER.in_days.to_i)))
 
 .w-min
-  = render(HovercardWithVersion::Component.new(version: @saved_scenario.version))
+  = render(HovercardWithVersion::Component.new(version: @saved_scenario.version.tag))
 
 .flex.gap-5.mt-5.mb-5.pb-5.border-b.border-solid.border-gray-200
   - if @saved_scenario.featured?

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.dsn = 'https://60adefe39e63b5ed6dd418b3fc8b16ca@o187050.ingest.us.sentry.io/4508620397871104'
+  # config.dsn = 'https://60adefe39e63b5ed6dd418b3fc8b16ca@o187050.ingest.us.sentry.io/4508620397871104'
 
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for tracing.

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  # config.dsn = 'https://60adefe39e63b5ed6dd418b3fc8b16ca@o187050.ingest.us.sentry.io/4508620397871104'
+  config.dsn = Settings.sentry_dsn
 
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for tracing.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,3 +30,7 @@ mailer:
 
 auth:
   issuer: <%= ENV.fetch('OPENID_ISSUER', 'http://localhost:3002') %>
+
+# Optionally send error messages to the Sentry service by providing your
+# Sentry DSN:
+sentry_dsn: <%= ENV['SENTRY_DSN'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,8 +10,6 @@ myetm:
   iss: my-etm
   uri: <%= ENV.fetch('OPENID_ISSUER', 'http://localhost:3002') %>
 
-collections_url: <%= ENV.fetch('COLLECTIONS_URL', 'http://localhost:3005') %>
-
 mailchimp:
   newsletter:
     list_url: <%= ENV.fetch('MAILCHIMP_LIST_URL', nil) %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,8 +1,10 @@
-
+# Staff applications – local devlopment
 etmodel:
   uri: http://localhost:3001
 etengine:
   uri: http://localhost:3000
+collections:
+  uri: http://localhost:3005
 
 myetm:
   iss: my-etm

--- a/db/migrate/20250116141434_create_versions.rb
+++ b/db/migrate/20250116141434_create_versions.rb
@@ -1,0 +1,12 @@
+class CreateVersions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :versions do |t|
+      t.string :tag, null: false
+      t.string :url_prefix
+      t.boolean :default, default: false
+      t.timestamps
+    end
+
+    add_index :versions, :tag, unique: true
+  end
+end

--- a/db/migrate/20250116141434_create_versions.rb
+++ b/db/migrate/20250116141434_create_versions.rb
@@ -9,6 +9,30 @@ class CreateVersions < ActiveRecord::Migration[7.2]
 
     add_index :versions, :tag, unique: true
 
+    # Rename old versions
+    rename_column :saved_scenarios, :version, :version_old
+    rename_column :collections, :version, :version_old
+
+    # Add foreign keys
     add_reference :oauth_applications, :version, foreign_key: true
+    add_reference :saved_scenarios, :version, foreign_key: true
+    add_reference :collections, :version, foreign_key: true
+
+    # Migrate saved scenarios and collections to use db Versions
+    default = Version.create!(default: true, tag: :latest)
+    SavedScenario.where(version_old: 'latest').update_all(version_id: default.id)
+    Collection.where(version_old: 'latest').update_all(version_id: default.id)
+
+    stable1 = Version.create!(tag: 'stable.01', url_prefix: 'stable')
+    SavedScenario.where(version_old: 'stable.01').update_all(version_id: stable1.id)
+    Collection.where(version_old: 'stable.01').update_all(version_id: stable1.id)
+
+    stable2 = Version.create!(tag: 'stable.02', url_prefix: 'stable2')
+    SavedScenario.where(version_old: 'stable.02').update_all(version_id: stable2.id)
+    Collection.where(version_old: 'stable.02').update_all(version_id: stable2.id)
+
+    # Clean up
+    remove_column(:saved_scenarios, :version_old)
+    remove_column(:collections, :version_old)
   end
 end

--- a/db/migrate/20250116141434_create_versions.rb
+++ b/db/migrate/20250116141434_create_versions.rb
@@ -8,5 +8,7 @@ class CreateVersions < ActiveRecord::Migration[7.2]
     end
 
     add_index :versions, :tag, unique: true
+
+    add_reference :oauth_applications, :version, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_03_170342) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -220,6 +220,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_03_170342) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "versions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "tag", null: false
+    t.string "url_prefix"
+    t.boolean "default", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag"], name: "index_versions_on_tag", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,12 +68,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
     t.string "title", null: false
     t.string "area_code"
     t.integer "end_year"
-    t.string "version", default: "latest"
     t.datetime "created_at", null: false
     t.datetime "discarded_at"
     t.boolean "interpolation", default: true
+    t.bigint "version_id"
     t.index ["discarded_at"], name: "index_collections_on_discarded_at"
     t.index ["user_id"], name: "index_collections_on_user_id"
+    t.index ["version_id"], name: "index_collections_on_version_id"
   end
 
   create_table "featured_scenario_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -171,15 +172,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
     t.integer "scenario_id", null: false
     t.text "scenario_id_history"
     t.string "title", null: false
-    t.string "version", default: "latest"
     t.string "area_code", null: false
     t.integer "end_year", null: false
     t.boolean "private", default: false
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "version_id"
     t.index ["discarded_at"], name: "index_saved_scenarios_on_discarded_at"
     t.index ["scenario_id"], name: "index_saved_scenarios_on_scenario_id"
+    t.index ["version_id"], name: "index_saved_scenarios_on_version_id"
   end
 
   create_table "sessions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -239,6 +241,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
   add_foreign_key "collection_saved_scenarios", "saved_scenarios"
   add_foreign_key "collection_scenarios", "collections"
   add_foreign_key "collections", "users"
+  add_foreign_key "collections", "versions"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
@@ -247,6 +250,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "personal_access_tokens", "oauth_access_tokens"
   add_foreign_key "personal_access_tokens", "users"
+  add_foreign_key "saved_scenarios", "versions"
   add_foreign_key "staff_applications", "oauth_applications", column: "application_id"
   add_foreign_key "staff_applications", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -135,8 +135,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
     t.integer "owner_id", null: false
     t.string "owner_type", null: false
     t.boolean "first_party", default: false, null: false
+    t.bigint "version_id"
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+    t.index ["version_id"], name: "index_oauth_applications_on_version_id"
   end
 
   create_table "oauth_openid_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -241,6 +243,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
+  add_foreign_key "oauth_applications", "versions"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "personal_access_tokens", "oauth_access_tokens"
   add_foreign_key "personal_access_tokens", "users"

--- a/lib/myetm/auth.rb
+++ b/lib/myetm/auth.rb
@@ -76,6 +76,7 @@ module MyEtm
       JWT.encode(payload, key, "RS256", typ: "JWT", kid: key.to_jwk["kid"])
     end
 
+    # TODO: Handle errors better
     # Returns a Faraday client for a user, which will send requests to the specified client app.
     #
     # If scopes are specified (e.g. from an access token) these scopes are granted
@@ -99,15 +100,15 @@ module MyEtm
     #
     # If scopes are specified (e.g. from an access token) these scopes are granted
     # Otherwise the configured app scopes are used
-    def engine_client(user, version_tag = Version::DEFAULT_TAG, scopes: [])
-      uri = Version.engine_url(version_tag)
+    def engine_client(user, version_tag = Version.default.tag, scopes: [])
+      uri = Version.find_by(tag: version_tag)&.engine_url
       engine = OAuthApplication.find_by(uri: uri)
       client_for(user, engine, scopes: scopes)
     end
 
     # Returns a Faraday client for a version of ETModel
-    def model_client(user, version_tag = Version::DEFAULT_TAG)
-      uri = Version.model_url(version_tag)
+    def model_client(user, version_tag = Version.default.tag)
+      uri = Version.find_by(tag: version_tag)&.model_url
       model = OAuthApplication.find_by(uri: uri)
       client_for(user, model)
     end

--- a/lib/myetm/auth.rb
+++ b/lib/myetm/auth.rb
@@ -100,16 +100,14 @@ module MyEtm
     #
     # If scopes are specified (e.g. from an access token) these scopes are granted
     # Otherwise the configured app scopes are used
-    def engine_client(user, version_tag = Version.default.tag, scopes: [])
-      uri = Version.find_by(tag: version_tag)&.engine_url
-      engine = OAuthApplication.find_by(uri: uri)
+    def engine_client(user, version = Version.default, scopes: [])
+      engine = OAuthApplication.find_by(uri: version.engine_url)
       client_for(user, engine, scopes: scopes)
     end
 
     # Returns a Faraday client for a version of ETModel
-    def model_client(user, version_tag = Version.default.tag)
-      uri = Version.find_by(tag: version_tag)&.model_url
-      model = OAuthApplication.find_by(uri: uri)
+    def model_client(user, version = Version.default.tag)
+      model = OAuthApplication.find_by(uri: version.model_url)
       client_for(user, model)
     end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Users::SessionsController do
       name: 'Test Application',
       uri: 'https://example.com',
       redirect_uri: 'https://example.com/auth/callback',
-      owner: user
+      owner: user,
+      version: Version.default
     )
   end
 

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     area_code { 'nl' }
     title { 'My Collection' }
     end_year { 2050 }
+    version { Version.find_by(tag: "latest") }
 
     transient do
       scenarios_count { 2 }

--- a/spec/factories/saved_scenario.rb
+++ b/spec/factories/saved_scenario.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     end_year { 2050 }
     area_code { 'nl' }
     scenario_id { 648_695 }
-    version { Version.find_by(tag: "latest").tag }
+    version { Version.find_by(tag: "latest") }
 
     after(:create) do |saved_scenario, evaluator|
       if evaluator.user.present?

--- a/spec/factories/saved_scenario.rb
+++ b/spec/factories/saved_scenario.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     end_year { 2050 }
     area_code { 'nl' }
     scenario_id { 648_695 }
-    version { 'latest' }
+    version { Version.find_by(tag: "latest").tag }
 
     after(:create) do |saved_scenario, evaluator|
       if evaluator.user.present?

--- a/spec/factories/version.rb
+++ b/spec/factories/version.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :version do
+    sequence(:tag) { |n| "version.#{n}" }
+    sequence(:url_prefix) { |n| "version-#{n}" }
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Collection, type: :model do
   describe 'scenario versions' do
     let(:user) { create(:user) }
 
-    let(:version) { "version" }
-    let(:version_1) { "version_1" }
+    let(:version) { create(:version) }
+    let(:version_1) { create(:version) }
 
     # We don't validate to be able to stub the versions
     let(:scenario1) do

--- a/spec/models/saved_scenario_spec.rb
+++ b/spec/models/saved_scenario_spec.rb
@@ -66,4 +66,27 @@ RSpec.describe SavedScenario, type: :model do
       expect(subject.restore_historical(999_999)).to be_nil
     end
   end
+
+  describe 'version=' do
+    let(:version) { create(:version) }
+    let(:saved_scenario) { create(:saved_scenario) }
+
+    context 'with a version object' do
+      it 'sets the version' do
+        expect { saved_scenario.version = version }
+          .to change {
+            saved_scenario.version.tag
+          }.to eq(version.tag)
+      end
+    end
+
+    context 'with a string tag' do
+      it 'sets the version' do
+        expect { saved_scenario.version = version.tag }
+          .to change {
+            saved_scenario.version.tag
+          }.to eq(version.tag)
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,15 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
+  # config.before(:suite) do
+  #   # Seed initial Version data for specs
+  #   Version.create!([
+  #     { tag: "latest", url_prefix: "", default: true },
+  #     { tag: "stable.01", url_prefix: "stable." },
+  #     { tag: "stable.02", url_prefix: "stable2." }
+  #   ])
+  # end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,14 +39,21 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
-  # config.before(:suite) do
-  #   # Seed initial Version data for specs
-  #   Version.create!([
-  #     { tag: "latest", url_prefix: "", default: true },
-  #     { tag: "stable.01", url_prefix: "stable." },
-  #     { tag: "stable.02", url_prefix: "stable2." }
-  #   ])
-  # end
+  config.before(:suite) do
+    # Ensure the test database has the required Version records
+    versions = [
+      { tag: "latest", url_prefix: "", default: true },
+      { tag: "stable.01", url_prefix: "stable." },
+      { tag: "stable.02", url_prefix: "stable2." }
+    ]
+
+    versions.each do |version_data|
+      Version.find_or_create_by!(tag: version_data[:tag]) do |version|
+        version.url_prefix = version_data[:url_prefix]
+        version.default = version_data[:default]
+      end
+    end
+  end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,19 +40,13 @@ RSpec.configure do |config|
   ]
 
   config.before(:suite) do
-    # Ensure the test database has the required Version records
-    versions = [
+    Version.delete_all # Clears existing records to avoid duplication
+
+    Version.create!([
       { tag: "latest", url_prefix: "", default: true },
       { tag: "stable.01", url_prefix: "stable." },
       { tag: "stable.02", url_prefix: "stable2." }
-    ]
-
-    versions.each do |version_data|
-      Version.find_or_create_by!(tag: version_data[:tag]) do |version|
-        version.url_prefix = version_data[:url_prefix]
-        version.default = version_data[:default]
-      end
-    end
+    ])
   end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe "API::Collections", type: :request, api: true do
   let!(:saved_scenarios) { create_list(:saved_scenario, 2, user: user) }
   let!(:collection) { create(:collection, user: user) }
 
-  before do
-    allow(Settings).to receive(:collections_url).and_return('http://example.com/collections')
-  end
-
   describe 'GET /api/v1/collections' do
     let!(:discarded_collection) { create(:collection, user: user, discarded_at: Time.current) }
 

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe "API::Collections", type: :request, api: true do
       {
         collection: {
           title: 'Test Collection',
-          version: '1.0',
           saved_scenario_ids: saved_scenarios.map(&:id)
         }
       }

--- a/spec/requests/api/featured_scenarios_spec.rb
+++ b/spec/requests/api/featured_scenarios_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'FeaturedScenarios API', type: :request do
         scenario.save(validate: false)
         create(:featured_scenario, saved_scenario: scenario)
 
-        get '/api/v1/featured_scenarios', as: :json, params: { version: 'old' }
+        get '/api/v1/featured_scenarios', as: :json, params: { version: "old" }
       end
 
       it 'returns featured_scenarios that are old' do

--- a/spec/requests/api/featured_scenarios_spec.rb
+++ b/spec/requests/api/featured_scenarios_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe 'FeaturedScenarios API', type: :request do
         scenario.save(validate: false)
         create(:featured_scenario, saved_scenario: scenario)
 
-        get '/api/v1/featured_scenarios', as: :json, params: { version:version }
+        get '/api/v1/featured_scenarios', as: :json, params: { version: version.tag }
       end
 
-      it 'returns featured_scenarios that are old' do
+      it 'returns featured_scenarios that are from the version' do
         expect(response).to have_http_status(:ok)
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['featured_scenarios'].size).to eq(1)
@@ -46,7 +46,7 @@ RSpec.describe 'FeaturedScenarios API', type: :request do
           expect(scenario.keys).to contain_exactly(
             'id', 'saved_scenario_id', 'owner_id', 'group', 'title_en', 'title_nl', 'version', 'end_year', 'author'
           )
-          expect(scenario['version']).to eq(version)
+          expect(scenario['version']).to eq(version.tag)
         end
       end
     end

--- a/spec/requests/api/featured_scenarios_spec.rb
+++ b/spec/requests/api/featured_scenarios_spec.rb
@@ -27,12 +27,14 @@ RSpec.describe 'FeaturedScenarios API', type: :request do
     end
 
     context 'when specifying a version' do
+      let(:version) { create(:version) }
+
       before do
-        scenario = build(:saved_scenario, version: "old")
+        scenario = build(:saved_scenario, version: version)
         scenario.save(validate: false)
         create(:featured_scenario, saved_scenario: scenario)
 
-        get '/api/v1/featured_scenarios', as: :json, params: { version: "old" }
+        get '/api/v1/featured_scenarios', as: :json, params: { version:version }
       end
 
       it 'returns featured_scenarios that are old' do
@@ -44,7 +46,7 @@ RSpec.describe 'FeaturedScenarios API', type: :request do
           expect(scenario.keys).to contain_exactly(
             'id', 'saved_scenario_id', 'owner_id', 'group', 'title_en', 'title_nl', 'version', 'end_year', 'author'
           )
-          expect(scenario['version']).to eq('old')
+          expect(scenario['version']).to eq(version)
         end
       end
     end

--- a/spec/requests/api/saved_scenarios_spec.rb
+++ b/spec/requests/api/saved_scenarios_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
 
       it 'returns the scenario' do
         request
+        user.saved_scenarios.reload
         expect(JSON.parse(response.body)).to eq(user.saved_scenarios.last.as_json)
       end
     end
@@ -235,9 +236,9 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
         access_token_header(user, :read)
       end
 
-      it 'returns forbidden' do
+      it 'returns not found' do
         request
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:not_found)
       end
 
       it 'does not create a saved scenario' do

--- a/spec/requests/api/saved_scenarios_spec.rb
+++ b/spec/requests/api/saved_scenarios_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
 
       it 'returns the scenario' do
         request
-        user.saved_scenarios.reload
+
         expect(JSON.parse(response.body)).to eq(user.saved_scenarios.last.as_json)
       end
     end
@@ -236,9 +236,9 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
         access_token_header(user, :read)
       end
 
-      it 'returns not found' do
+      it 'returns forbidden' do
         request
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it 'does not create a saved scenario' do


### PR DESCRIPTION
This PR turns Versions into a database entity and fixes the fallout in spec and throughout the application.

Versions have:
- A tag (e.g. "latest")
- A url_prefix (e.g "stable2."
- A boolean 'default' attribute

I have associated versions and OAuthApplications. I also added a config that seeds the versions in the rails_helper for the spec.


**Edit**: The tests pass locally but are failing because the Semaphore CI doesn't run my seeding logic - is there a way around that without seeding the versions into the actual environment @noracato? Otherwise we can make a db/seeds/test.rb and ask semaphore to seed that file before running.