### PR TITLE
Disabled turbo on identity changing forms

### DIFF
--- a/app/views/identity/settings/edit_email.html.erb
+++ b/app/views/identity/settings/edit_email.html.erb
@@ -1,6 +1,6 @@
 <%= render(ModalComponent.new(title: t('.title'))) do |modal| %>
   <%= turbo_frame_tag :change_email_form do %>
-    <%= form_for(@user, url: identity_edit_email_path, html: { method: :post }) do |f| %>
+    <%= form_for(@user, url: identity_edit_email_path, html: { method: :post, data: { turbo: false } }) do |f| %>
       <%= render(FormSteps::WrapperComponent.new) do |steps| %>
         <%= render(FormSteps::RowComponent.new(title: t('identity.settings.edit_password.current_password'), hint: t('identity.settings.edit_password.current_password_hint'), label_for: "user_current_password")) do |row| %>
           <div class="relative">

--- a/app/views/identity/settings/edit_name.html.erb
+++ b/app/views/identity/settings/edit_name.html.erb
@@ -1,6 +1,6 @@
 <%= render(ModalComponent.new(title: t('.title'))) do |modal| %>
   <%= turbo_frame_tag :change_name_form do %>
-    <%= form_for(@user, url: identity_edit_name_path, html: { method: :post }) do |f| %>
+    <%= form_for(@user, url: identity_edit_name_path, html: { method: :post, data: { turbo: false } }) do |f| %>
       <%= render(FormSteps::WrapperComponent.new) do |steps| %>
         <%= render(FormSteps::RowComponent.new(title: t('.new_name'), label_for: "user_name", hint: t('.new_name_hint'))) do |row| %>
           <%= f.text_field :name, value: @user.name, required: true, autofocus: true, autocomplete: 'name', class: "field" %>

--- a/app/views/identity/settings/edit_password.html.erb
+++ b/app/views/identity/settings/edit_password.html.erb
@@ -1,6 +1,6 @@
 <%= render(ModalComponent.new(title: t('.title'))) do |modal| %>
   <%= turbo_frame_tag :change_password_form do %>
-    <%= form_for(@user, url: identity_edit_password_path, html: { method: :post }) do |f| %>
+    <%= form_for(@user, url: identity_edit_password_path, html: { method: :post, data: { turbo: false } }) do |f| %>
       <%= render(FormSteps::WrapperComponent.new) do |steps| %>
         <%= render(FormSteps::RowComponent.new(title: t('.current_password'), hint: t('.current_password_hint'), label_for: "user_current_password")) do |row| %>
           <div class="relative">


### PR DESCRIPTION
Resolved the 'content-missing' issues by disabling turbo in identity related forms.