### PR TITLE
Adding content_for title's where missing in html files

### DIFF
--- a/app/views/admin/collections/index.html.haml
+++ b/app/views/admin/collections/index.html.haml
@@ -1,4 +1,5 @@
 - content_for :menu_title, "All collections"
+- content_for :title, "All collections"
 = render(partial: "block_right_sub_menu", locals: { has_collections: @collections.present? })
 = render(partial: "/admin/block_right_menu")
 

--- a/app/views/admin/staff_applications/index.html.haml
+++ b/app/views/admin/staff_applications/index.html.haml
@@ -1,4 +1,5 @@
 - content_for :menu_title, 'Your Applications'
+- content_for :title, 'Your Applications'
 = render partial: '/admin/block_right_menu'
 
 = render partial: 'intro'

--- a/app/views/admin/users/all.html.erb
+++ b/app/views/admin/users/all.html.erb
@@ -1,4 +1,5 @@
 <%- content_for :menu_title, 'Manage users' %>
+<%- content_for :title, 'Manage users' %>
 <%= render(partial: "/admin/block_right_menu") %>
 
 <div class="mt-8 mb-2 text-midnight-400 text-sm">

--- a/app/views/admin/users/org.html.erb
+++ b/app/views/admin/users/org.html.erb
@@ -1,4 +1,5 @@
 <%- content_for :menu_title, 'Admin panel' %>
+<%- content_for :title, 'Admin panel' %>
 <%= render(partial: "/admin/block_right_menu") %>
 
 <div class="text-midnight-450">

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title, t('.title')) %>
+<% content_for(:title, t('.title')) %>
 <% content_for(:header) do %>
   <%= render(Login::HeaderComponent.new(
     title: t('.title'), #TODO configure locales

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title, t('.title')) %>
+<% content_for(:title, t('.title')) %>
 <% content_for(:header) do %>
   <%= render(Login::HeaderComponent.new(
     title: t('.title'),

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title, t('.title')) %>
+<% content_for(:title, t('.title')) %>
 <%= render(Login::HeaderComponent.new(
   title: t('.title'),
   subtext: t('.subtitle')

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title, t('.title')) %>
+<% content_for(:title, t('.title')) %>
 <% content_for(:header) do %>
   <%= render(Login::HeaderComponent.new(
     title: t('.title'), #TODO locales

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:page_title, t('.title')) %>
+<% content_for(:title, t('.title')) %>
 <% content_for(:header) do %>
   <%= render(Login::HeaderComponent.new(
     title: t('.title'),

--- a/app/views/doorkeeper/authorized_applications/index.html.erb
+++ b/app/views/doorkeeper/authorized_applications/index.html.erb
@@ -1,4 +1,5 @@
 <%= content_for(:page_title, t('identity.authorized_applications.index.title')) %>
+<%= content_for(:title, t('identity.authorized_applications.index.title')) %>
 <%= content_for(:menu_title, t('identity.authorized_applications.index.title')) %>
 <% render partial: 'identity/sidebar' %>
 

--- a/app/views/identity/settings/index.html.erb
+++ b/app/views/identity/settings/index.html.erb
@@ -1,4 +1,5 @@
 <%= content_for(:page_title, t('.title')) %>
+<%= content_for(:title, t('.title')) %>
 <%= content_for(:menu_title, t('.title')) %>
 <% render partial: 'identity/sidebar' %>
 

--- a/app/views/identity/tokens/index.html.erb
+++ b/app/views/identity/tokens/index.html.erb
@@ -1,4 +1,5 @@
 <%= content_for(:page_title, t('.title')) %>
+<%= content_for(:title, t('.title')) %>
 <%= content_for(:menu_title, t('.title')) %>
 <% render partial: 'identity/sidebar' %>
 

--- a/app/views/identity/tokens/new.html.erb
+++ b/app/views/identity/tokens/new.html.erb
@@ -1,4 +1,5 @@
 <%= content_for(:page_title, t('.title')) %>
+<%= content_for(:title, t('.title')) %>
 <% render partial: 'identity/sidebar' %>
 
 <%= render(Identity::PageHeaderComponent.new(

--- a/app/views/static_pages/collaborate.html.haml
+++ b/app/views/static_pages/collaborate.html.haml
@@ -1,4 +1,5 @@
 - content_for(:page_title) { t('collaborate.collaborate.title') }
+- content_for(:title) { t('collaborate.collaborate.title') }
 - content_for(:menu_title) { t('collaborate.collaborate.title') }
 = render(partial: "block_right")
 

--- a/app/views/static_pages/contact.html.haml
+++ b/app/views/static_pages/contact.html.haml
@@ -1,4 +1,5 @@
 - content_for(:page_title) { t('contact.contact.title') }
+- content_for(:title) { t('contact.contact.title') }
 - content_for(:menu_title) { t('contact.contact.title') }
 = render(partial: "block_right")
 

--- a/app/views/static_pages/privacy.html.haml
+++ b/app/views/static_pages/privacy.html.haml
@@ -1,4 +1,5 @@
 - content_for(:page_title) { t('privacy.privacy.title') }
+- content_for(:title) { t('privacy.privacy.title') }
 - content_for(:menu_title) { t('privacy.privacy.title') }
 = render(partial: "block_right")
 

--- a/app/views/static_pages/terms.html.haml
+++ b/app/views/static_pages/terms.html.haml
@@ -1,4 +1,5 @@
 - content_for(:page_title) { t('terms.terms.title') }
+- content_for(:title) { t('terms.terms.title') }
 - content_for(:menu_title) { t('terms.terms.title') }
 = render(partial: "block_right")
 


### PR DESCRIPTION
This PR Adds the page titles for the html files where this was missing. 