### PR TITLE
Scenario history: update descriptions and restore

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -36,6 +36,7 @@
   .button-warning {
     @apply bg-red-600;
     @apply text-midnight-200;
+    @apply hover:bg-midnight-950;
   }
 
   .button-primary {

--- a/app/components/history/row/component.html.erb
+++ b/app/components/history/row/component.html.erb
@@ -1,7 +1,10 @@
-<turbo-frame id="<%=@tag%>>"
+<turbo-frame id="<%=@tag%>">
+  <%= form_for(@historical_version, url: @update_path, html: { method: :put }) do |f| %>
 <%# TODO: lets do the edit with stimulus (show form) and destroy with turbo (call service, remove frame) %>
-<%# <%= form_for(@historical_version, url: @update_path, html: { method: :put, class: '' }) do |f|%> %>
-  <div class="grid grid-cols-4 gap-5 w-full transition mb-5 p-2 pr-4 rounded-md">
+  <div
+    class="grid grid-cols-4 gap-5 w-full transition mb-5 p-2 pr-4 rounded-md"
+    data-controller="toggle-form"
+    >
     <%# GRID COL 1 %>
     <div class="flex">
       <span class="
@@ -11,7 +14,7 @@
         w-8
         mr-5
         pt-1
-        my-auto
+        mt-1
         text-center
         text-midnight-200"
       >
@@ -27,33 +30,48 @@
 
     <%# GRID COL 2/3 %>
     <div class="text-midnight-400 col-span-2 text-sm mt-3">
-      <%= form_for(@historical_version, url: @update_path, html: { method: :put }) do |f| %>
-        <div class="">
+        <div  data-toggle-form-target="content">
           <%= description %>
         </div>
-        <div class="hidden">
-          <%= f.text_area :description, required: true, placeholder: '...' %>
+        <div data-toggle-form-target="editcontent" class="hidden">
+          <%= f.text_area :description, required: true, placeholder: '...', class: 'resize-none w-full h-[200px]' %>
         </div>
+    </div>
+
+    <%# GRID COL 4 %>
+    <div class="flex mt-2 text-midnight-400" data-toggle-form-target="controls">
+      <% if @collaborator %>
+        <span class="mr-0 ml-auto p-2 pl-6">
+          <%= render(Hovercard::Component.new(path: '', text: 'edit text')) do %>
+            <div class="transition text-sm hover:text-midnight-800 hover:cursor-pointer" data-action="click->toggle-form#show">
+              <%= helpers.heroicon 'pencil', options: { class: 'w-5 h-5' } %>
+            </div>
+          <% end %>
+        </span>
+      <% end %>
+      <% if @owner %>
+        <span class="mr-0 ml-2 p-2 pl-6">
+          <%= render(Hovercard::Component.new(path: '', text: 'restore')) do %>
+            <%# TODO: implement restore! %>
+            <%= link_to @update_path, class: "transition text-sm hover:text-midnight-800 hover:cursor-pointer" do%>
+              <%= helpers.heroicon 'arrow-uturn-left', options: { class: 'w-5 h-5' } %>
+            <% end %>
+          <% end %>
+        </span>
       <% end %>
     </div>
 
     <%# GRID COL 4 %>
-    <div class="flex mt-2 text-midnight-400">
-      <%# TODO: add if statements in order to only show edit for collabs and restore for owners %>
+    <div class="hidden flex mt-2 text-midnight-400" data-toggle-form-target="editcontrols">
       <span class="mr-0 ml-auto p-2 pl-6">
-        <%= render(Hovercard::Component.new(path: '', text: 'edit text')) do %>
-          <%= link_to @update_path, class: "transition text-sm hover:text-midnight-800" do%>
-            <%= helpers.heroicon 'pencil', options: { class: 'w-5 h-5' } %>
-          <% end %>
-        <% end %>
+        <%= f.submit t('.update'), class: button_classes(color: :success) %>
       </span>
-      <span class="mr-0 ml-2 p-2 pl-6">
-        <%= render(Hovercard::Component.new(path: '', text: 'restore')) do %>
-          <%= link_to @update_path, class: "transition text-sm hover:text-midnight-800" do%>
-            <%= helpers.heroicon 'arrow-uturn-left', options: { class: 'w-5 h-5' } %>
-          <% end %>
-        <% end %>
+      <span class="mr-0 ml-2 p-2 pt-3">
+        <span class="<%= button_classes('py-2') %>" data-action="click->toggle-form#hide">
+          <%= t('.cancel') %>
+        </span>
       </span>
     </div>
   </div>
+  <% end %>
 </turbo-frame>

--- a/app/components/history/row/component.html.erb
+++ b/app/components/history/row/component.html.erb
@@ -1,5 +1,4 @@
 <%= form_for(@historical_version, url: @update_path, html: { method: :put }) do |f| %>
-<%# TODO: lets do the edit with stimulus (show form) and destroy with turbo (call service, remove frame) %>
   <div
     class="grid grid-cols-4 gap-5 w-full transition mb-5 p-2 pr-4 rounded-md"
     data-controller="toggle-form"
@@ -41,20 +40,19 @@
     <div class="flex mt-2 text-midnight-400" data-toggle-form-target="controls">
       <% if @collaborator %>
         <span class="mr-0 ml-auto p-2 pl-6">
-          <%= render(Hovercard::Component.new(path: '', text: 'edit text')) do %>
-            <div class="transition text-sm hover:text-midnight-800 hover:cursor-pointer" data-action="click->toggle-form#show">
+          <%= render(Hovercard::Component.new(path: '', text: t('.edit_description'))) do %>
+            <div class="transition text-sm hover:text-midnight-800 hover:cursor-pointer" data-action="click->toggle-form#showEdit">
               <%= helpers.heroicon 'pencil', options: { class: 'w-5 h-5' } %>
             </div>
           <% end %>
         </span>
       <% end %>
-      <% if @owner %>
+      <% if @owner && @restorable %>
         <span class="mr-0 ml-2 p-2 pl-6">
-          <%= render(Hovercard::Component.new(path: '', text: 'restore')) do %>
-            <%# TODO: implement restore! %>
-            <%= link_to @update_path, class: "transition text-sm hover:text-midnight-800 hover:cursor-pointer" do%>
+          <%= render(Hovercard::Component.new(path: '', text: t('.restore_description'))) do %>
+            <div class="transition text-sm hover:text-midnight-800 hover:cursor-pointer" data-action="click->toggle-form#showRestore">
               <%= helpers.heroicon 'arrow-uturn-left', options: { class: 'w-5 h-5' } %>
-            <% end %>
+            </div>
           <% end %>
         </span>
       <% end %>
@@ -66,7 +64,21 @@
         <%= f.submit t('.update'), class: button_classes(color: :success) %>
       </span>
       <span class="mr-0 ml-2 p-2 pt-3">
-        <span class="<%= button_classes('py-2') %>" data-action="click->toggle-form#hide">
+        <span class="<%= button_classes('py-2') %>" data-action="click->toggle-form#hideEditEdit">
+          <%= t('.cancel') %>
+        </span>
+      </span>
+    </div>
+
+    <%# GRID COL 4 %>
+    <div class="hidden flex mt-2 text-midnight-400" data-toggle-form-target="restorecontrols">
+      <span class="mr-0 ml-auto p-2 pl-6">
+        <%= link_to @restore_path, method: :put, data: { 'turbo-method': :put }, class: button_classes(color: :warning) do%>
+          <%= t('.restore') %>
+        <% end %>
+      </span>
+      <span class="mr-0 ml-2 p-2">
+        <span class="<%= button_classes() %>" data-action="click->toggle-form#hideRestore">
           <%= t('.cancel') %>
         </span>
       </span>

--- a/app/components/history/row/component.html.erb
+++ b/app/components/history/row/component.html.erb
@@ -1,5 +1,4 @@
-<turbo-frame id="<%=@tag%>">
-  <%= form_for(@historical_version, url: @update_path, html: { method: :put }) do |f| %>
+<%= form_for(@historical_version, url: @update_path, html: { method: :put }) do |f| %>
 <%# TODO: lets do the edit with stimulus (show form) and destroy with turbo (call service, remove frame) %>
   <div
     class="grid grid-cols-4 gap-5 w-full transition mb-5 p-2 pr-4 rounded-md"
@@ -73,5 +72,4 @@
       </span>
     </div>
   </div>
-  <% end %>
-</turbo-frame>
+<% end %>

--- a/app/components/history/row/component.html.erb
+++ b/app/components/history/row/component.html.erb
@@ -26,13 +26,16 @@
     </div>
 
     <%# GRID COL 2/3 %>
-    <span class="text-midnight-400 col-span-2 text-sm mt-3">
-      <% if @historical_version.description.presence %>
-        <%= @historical_version.description %>
-      <% else %>
-        <%= t('history.empty_message') %>
+    <div class="text-midnight-400 col-span-2 text-sm mt-3">
+      <%= form_for(@historical_version, url: @update_path, html: { method: :put }) do |f| %>
+        <div class="">
+          <%= description %>
+        </div>
+        <div class="hidden">
+          <%= f.text_area :description, required: true, placeholder: '...' %>
+        </div>
       <% end %>
-    </span>
+    </div>
 
     <%# GRID COL 4 %>
     <div class="flex mt-2 text-midnight-400">

--- a/app/components/history/row/component.html.erb
+++ b/app/components/history/row/component.html.erb
@@ -1,4 +1,4 @@
-<turbo-frame id=<%=@tag%>>
+<turbo-frame id="<%=@tag%>>"
 <%# TODO: lets do the edit with stimulus (show form) and destroy with turbo (call service, remove frame) %>
 <%# <%= form_for(@historical_version, url: @update_path, html: { method: :put, class: '' }) do |f|%> %>
   <div class="grid grid-cols-4 gap-5 w-full transition mb-5 p-2 pr-4 rounded-md">
@@ -43,14 +43,14 @@
       <span class="mr-0 ml-auto p-2 pl-6">
         <%= render(Hovercard::Component.new(path: '', text: 'edit text')) do %>
           <%= link_to @update_path, class: "transition text-sm hover:text-midnight-800" do%>
-            <%= heroicon 'pencil', options: { class: 'w-5 h-5' } %>
+            <%= helpers.heroicon 'pencil', options: { class: 'w-5 h-5' } %>
           <% end %>
         <% end %>
       </span>
       <span class="mr-0 ml-2 p-2 pl-6">
         <%= render(Hovercard::Component.new(path: '', text: 'restore')) do %>
           <%= link_to @update_path, class: "transition text-sm hover:text-midnight-800" do%>
-            <%= heroicon 'arrow-uturn-left', options: { class: 'w-5 h-5' } %>
+            <%= helpers.heroicon 'arrow-uturn-left', options: { class: 'w-5 h-5' } %>
           <% end %>
         <% end %>
       </span>

--- a/app/components/history/row/component.rb
+++ b/app/components/history/row/component.rb
@@ -3,12 +3,14 @@ module History::Row
     include Turbo::FramesHelper
     include ButtonHelper
 
-    def initialize(historical_version:, tag:, update_path:, owner: false, collaborator: false)
+    def initialize(historical_version:, tag:, update_path:, restore_path:, owner: false, collaborator: false, restorable: true)
       @historical_version = historical_version
       @tag = tag
       @update_path = update_path
+      @restore_path = restore_path
       @owner = owner
       @collaborator = collaborator
+      @restorable = restorable
     end
 
     def description

--- a/app/components/history/row/component.rb
+++ b/app/components/history/row/component.rb
@@ -5,5 +5,13 @@ module History::Row
     option :historical_version
     option :tag
     option :update_path
+
+    def description
+      if @historical_version.description.presence
+        @historical_version.description
+      else
+        t("history.empty_message")
+      end
+    end
   end
 end

--- a/app/components/history/row/component.rb
+++ b/app/components/history/row/component.rb
@@ -1,17 +1,15 @@
 module History::Row
-  class Component < ApplicationComponent
+  class Component < ViewComponent::Base
     include Turbo::FramesHelper
 
-    option :historical_version
-    option :tag
-    option :update_path
+    def initialize(historical_version:, tag:, update_path:)
+      @historical_version = historical_version
+      @tag = tag
+      @update_path = update_path
+    end
 
     def description
-      if @historical_version.description.presence
-        @historical_version.description
-      else
-        t("history.empty_message")
-      end
+      @historical_version.description.presence || t("history.empty_message")
     end
   end
 end

--- a/app/components/history/row/component.rb
+++ b/app/components/history/row/component.rb
@@ -1,11 +1,14 @@
 module History::Row
   class Component < ViewComponent::Base
     include Turbo::FramesHelper
+    include ButtonHelper
 
-    def initialize(historical_version:, tag:, update_path:)
+    def initialize(historical_version:, tag:, update_path:, owner: false, collaborator: false)
       @historical_version = historical_version
       @tag = tag
       @update_path = update_path
+      @owner = owner
+      @collaborator = collaborator
     end
 
     def description

--- a/app/javascript/controllers/toggle_form_controller.js
+++ b/app/javascript/controllers/toggle_form_controller.js
@@ -1,19 +1,32 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["content", "editcontent", "controls", "editcontrols"]
+  static targets = [
+    "content", "editcontent", "controls", "editcontrols",
+    "restorecontrols"
+  ]
 
-  show(event) {
+  showEdit(event) {
     this.editcontentTarget.classList.remove("hidden")
     this.editcontrolsTarget.classList.remove("hidden")
     this.controlsTarget.classList.add("hidden")
     this.contentTarget.classList.add("hidden")
   }
 
-  hide(event) {
+  hideEdit(event) {
     this.editcontentTarget.classList.add("hidden")
     this.editcontrolsTarget.classList.add("hidden")
     this.controlsTarget.classList.remove("hidden")
     this.contentTarget.classList.remove("hidden")
+  }
+
+  showRestore(event) {
+    this.restorecontrolsTarget.classList.remove("hidden")
+    this.controlsTarget.classList.add("hidden")
+  }
+
+  hideRestore(event) {
+    this.restorecontrolsTarget.classList.add("hidden")
+    this.controlsTarget.classList.remove("hidden")
   }
 }

--- a/app/javascript/controllers/toggle_form_controller.js
+++ b/app/javascript/controllers/toggle_form_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["content", "editcontent", "controls", "editcontrols"]
+
+  show(event) {
+    this.editcontentTarget.classList.remove("hidden")
+    this.editcontrolsTarget.classList.remove("hidden")
+    this.controlsTarget.classList.add("hidden")
+    this.contentTarget.classList.add("hidden")
+  }
+
+  hide(event) {
+    this.editcontentTarget.classList.add("hidden")
+    this.editcontrolsTarget.classList.add("hidden")
+    this.controlsTarget.classList.remove("hidden")
+    this.contentTarget.classList.remove("hidden")
+  }
+}

--- a/app/models/saved_scenario/history.rb
+++ b/app/models/saved_scenario/history.rb
@@ -18,7 +18,7 @@ module SavedScenario::History
   # Public: Restores the scenario id to the given historical scenario
   # Returns the discarded scenarios from the history
   def restore_historical(scenario_id)
-    return unless scenario_id && contains?(scenario_id)
+    return [] unless scenario_id && contains?(scenario_id)
 
     discard_no = scenario_id_history.index(scenario_id)
     discarded = scenario_id_history[discard_no + 1...]

--- a/app/services/saved_scenario/restore.rb
+++ b/app/services/saved_scenario/restore.rb
@@ -33,8 +33,6 @@ class SavedScenario::Restore
 
   private
 
-  # TODO: remove version tags!
-
   def unprotect(scenario_id)
     ApiScenario::SetCompatibility.dont_keep_compatible(http_client, scenario_id)
   end

--- a/app/services/saved_scenario/restore.rb
+++ b/app/services/saved_scenario/restore.rb
@@ -19,7 +19,7 @@ class SavedScenario::Restore
     saved_scenario.tap do |ss|
       discarded_scenarios = ss.restore_historical(scenario_id)
 
-      return ServiceResult.success(saved_scenario) unless discarded_scenarios
+      return ServiceResult.success(saved_scenario) if discarded_scenarios.empty?
       return failure unless ss.valid?
 
       discarded_scenarios.each { |id| unprotect(id) }

--- a/app/views/saved_scenario_history/index.html.erb
+++ b/app/views/saved_scenario_history/index.html.erb
@@ -17,7 +17,9 @@
         tag: "scenario_#{historical_version.scenario_id}",
         update_path: saved_scenario_update_history_path(
             id: @saved_scenario.id, scenario_id: historical_version.scenario_id
-        )
+        ),
+        owner: @saved_scenario.owner?(current_user),
+        collaborator: @saved_scenario.collaborator?(current_user)
     )) %>
  <% end %>
 </div>

--- a/app/views/saved_scenario_history/index.html.erb
+++ b/app/views/saved_scenario_history/index.html.erb
@@ -12,6 +12,7 @@
 
 <div class="border border-gray-200 rounded-md p-2 pt-5 mt-2">
  <% @history.each do |historical_version| %>
+  <turbo-frame id="<%=@tag%>">
     <%= render(History::Row::Component.new(
         historical_version: historical_version,
         tag: "scenario_#{historical_version.scenario_id}",
@@ -21,5 +22,6 @@
         owner: @saved_scenario.owner?(current_user),
         collaborator: @saved_scenario.collaborator?(current_user)
     )) %>
+  </turbo-frame>
  <% end %>
 </div>

--- a/app/views/saved_scenario_history/index.html.erb
+++ b/app/views/saved_scenario_history/index.html.erb
@@ -19,8 +19,12 @@
         update_path: saved_scenario_update_history_path(
             id: @saved_scenario.id, scenario_id: historical_version.scenario_id
         ),
+        restore_path: saved_scenario_restore_history_path(
+            id: @saved_scenario.id, scenario_id: historical_version.scenario_id
+        ),
         owner: @saved_scenario.owner?(current_user),
-        collaborator: @saved_scenario.collaborator?(current_user)
+        collaborator: @saved_scenario.collaborator?(current_user),
+        restorable: @saved_scenario.scenario_id != historical_version.scenario_id
     )) %>
   </turbo-frame>
  <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,6 +166,11 @@ en:
       <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/managing-scenarios/scenario-version-history" target=\"_blank\">
       documentation</a> for more information.
     title: History
+  history:
+    row:
+      component:
+        update: 'Update'
+        cancel: 'Cancel'
   saved_scenarios:
     title: Saved scenarios
     empty: You don't have any scenarios.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,11 +166,17 @@ en:
       <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/managing-scenarios/scenario-version-history" target=\"_blank\">
       documentation</a> for more information.
     title: History
+    error: Something went wrong updating the history of your scenario
   history:
     row:
       component:
         update: 'Update'
         cancel: 'Cancel'
+        restore: 'Restore'
+        edit_description: |
+          Edit the description of this saved version. Save your notes on what you have changed.
+        restore_description: |
+          Restore the saved scenario to this version. This action is irreversible.
   saved_scenarios:
     title: Saved scenarios
     empty: You don't have any scenarios.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -142,7 +142,24 @@ nl:
         destroy: Er ging iets mis bij het verwijderen van de gebruiker van het scenario!
         general: Probeer het later nog eens. Neem contact met ons op als je deze foutmelding blijft krijgen.
         duplicate: Deze persoon is al uitgenodigd voor dit scenario.
-
+  saved_scenario_history:
+    description: |
+      Here you can see the history of your saved scenario. A description can be added to each historical version.
+      When you are owner of this scenario, you can reset the scenario to an older stage. See the
+      <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/managing-scenarios/scenario-version-history" target=\"_blank\">
+      documentation</a> for more information.
+    title: History
+    error: Something went wrong updating the history of your scenario
+  history:
+    row:
+      component:
+        update: 'Update'
+        cancel: 'Cancel'
+        restore: 'Restore'
+        edit_description: |
+          Edit the description of this saved version. Save your notes on what you have changed.
+        restore_description: |
+          Restore the saved scenario to this version. This action is irreversible.
   saved_scenarios:
     title: Opgeslagen scenario's
     empty: Je hebt nog geen scenario's.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
 
     get '/history' => 'saved_scenario_history#index'
     put '/history/:scenario_id' => 'saved_scenario_history#update',  as: :update_history
+    put '/history/:scenario_id/restore' => 'saved_scenario_history#restore',  as: :restore_history
   end
 
   namespace :api do

--- a/spec/controllers/saved_scenario_history_controller_spec.rb
+++ b/spec/controllers/saved_scenario_history_controller_spec.rb
@@ -63,5 +63,26 @@ describe SavedScenarioHistoryController, vcr: true do
         expect(response).to be_ok
       end
     end
+
+    describe 'PUT restore' do
+      before do
+        allow(ApiScenario::SetCompatibility).to receive(:call).and_return(
+          ServiceResult.success)
+
+        put :restore, format: :turbo_stream, params: {
+          saved_scenario_id: saved_scenario.id,
+          scenario_id: 111
+        }
+      end
+
+      it 'is succesful' do
+        expect(response).to be_ok
+      end
+
+      it 'restores the scenario' do
+        saved_scenario.reload
+        expect(saved_scenario.scenario_id).to eq(111)
+      end
+    end
   end
 end

--- a/spec/controllers/saved_scenario_history_controller_spec.rb
+++ b/spec/controllers/saved_scenario_history_controller_spec.rb
@@ -10,7 +10,15 @@ describe SavedScenarioHistoryController, vcr: true do
   let(:client) { Faraday.new(url: 'http://et.engine') }
 
   before do
-    allow(ApiScenario::VersionTags::Update).to receive(:call).and_return(ServiceResult.success)
+    allow(ApiScenario::VersionTags::Update).to receive(:call).and_return(
+      ServiceResult.success(
+        {
+          'user_id' => user.id,
+          'description' => 'my last version',
+          'last_updated_at' => 2.days.ago.to_json
+        }
+      )
+    )
     allow(ApiScenario::VersionTags::FetchAll).to receive(:call).and_return(ServiceResult.success(
       {
         "123" => {
@@ -44,10 +52,10 @@ describe SavedScenarioHistoryController, vcr: true do
 
     describe 'PUT update' do
       before do
-        put :update, format: :json, params: {
+        put :update, format: :turbo_stream, params: {
           saved_scenario_id: saved_scenario.id,
-          scenario_id: 123,
-          description: 'my update'
+          scenario_id: saved_scenario.scenario_id,
+          saved_scenario_history: { description: 'my update' }
         }
       end
 

--- a/spec/models/saved_scenario_spec.rb
+++ b/spec/models/saved_scenario_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SavedScenario, type: :model do
     end
 
     it 'does nothing when the scenario was not in the history' do
-      expect(subject.restore_historical(999_999)).to be_nil
+      expect(subject.restore_historical(999_999)).to be_empty
     end
   end
 


### PR DESCRIPTION
This PR completes the functionalities of editing descriptions of historical versions of saved scenarios, and restoring a saved scenario to a previous version in the front end.