### PR TITLE
Setting up to transfer saved scenario descriptions to beta

### DIFF
--- a/app/services/create_staff_application.rb
+++ b/app/services/create_staff_application.rb
@@ -27,7 +27,8 @@ module CreateStaffApplication
     app.attributes = app_config.to_model_attributes.merge(
       owner_id: user.id,
       uri: parsed_uri.to_s,
-      redirect_uri: redirect_uri.to_s
+      redirect_uri: redirect_uri.to_s,
+      version_id: Version.default.id
     )
 
     # Save the application and handle failures

--- a/db/migrate/20250124135352_add_tmp_description_to_saved_scenarios.rb
+++ b/db/migrate/20250124135352_add_tmp_description_to_saved_scenarios.rb
@@ -1,0 +1,5 @@
+class AddTmpDescriptionToSavedScenarios < ActiveRecord::Migration[7.2]
+  def change
+    add_column :saved_scenarios, :tmp_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_24_135352) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -179,6 +179,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_16_141434) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "version_id"
+    t.text "tmp_description"
     t.index ["discarded_at"], name: "index_saved_scenarios_on_discarded_at"
     t.index ["scenario_id"], name: "index_saved_scenarios_on_scenario_id"
     t.index ["version_id"], name: "index_saved_scenarios_on_version_id"

--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -24,8 +24,7 @@ namespace :data do
       "multi_year_chart_saved_scenarios" => "collection_saved_scenarios",
       "multi_year_chart_scenarios" => "collection_scenarios",
       "tmp_users_for_export" => "users",
-      "tmp_oauth_access_grants_for_export" => "oauth_access_grants",
-      "tmp_saved_scenarios_for_export" => "saved_scenarios",
+      "tmp_oauth_access_grants_for_export" => "oauth_access_grants"
     }
 
     # Map source columns to destination columns for specific tables
@@ -33,7 +32,7 @@ namespace :data do
       "multi_year_charts" => { "multi_year_chart_id" => "collection_id" },
       "multi_year_chart_saved_scenarios" => { "multi_year_chart_id" => "collection_id" },
       "multi_year_chart_scenarios" => { "multi_year_chart_id" => "collection_id" },
-      "saved_scenarios" => { "description" => nil }
+      "saved_scenarios" => { "description" => "tmp_description" }
     }
 
     TABLE_INSERT_ORDER = [

--- a/lib/tasks/transform_descriptions.rake
+++ b/lib/tasks/transform_descriptions.rake
@@ -1,0 +1,12 @@
+namespace :data do
+  desc "Transform tmp_description into Action Text description"
+  task transform_descriptions: :environment do
+    SavedScenario.find_each do |scenario|
+      next if scenario.tmp_description.blank?
+
+      # Assign Action Text description:
+      scenario.description = scenario.tmp_description
+      scenario.save!
+    end
+  end
+end


### PR DESCRIPTION
This PR also includes the version_id for local oauth applications.

It's main purpose is to:
- Add a migration for temporary descriptions
- Add a rake task to move temporary descriptions to action text
- Adjust the data import rake task appropriately