### PR TITLE
Updated descriptions rake task 

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,3 @@
-Rails.application.config.session_store(:cookie_store, key: '_myetm')
+# frozen_string_literal: true
+
+Etm::Application.config.session_store :active_record_store, key: "_myetm"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,1 @@
-# MyEtm::Application.config.session_store :active_record_store,
-#                                         key: "_idp_session",
-#                                         domain: '.energytransitionmodel.com',
-#                                         secure: Rails.env.production?,
-#                                         same_site: :none
-
 Rails.application.config.session_store(:cookie_store, key: '_myetm')

--- a/lib/tasks/transform_descriptions.rake
+++ b/lib/tasks/transform_descriptions.rake
@@ -4,9 +4,8 @@ namespace :data do
     SavedScenario.find_each do |scenario|
       next if scenario.tmp_description.blank?
 
-      # Assign Action Text description:
-      scenario.description = scenario.tmp_description
-      scenario.save!
+      # Update directly without changing updated_at:
+      scenario.update_columns(description: scenario.tmp_description)
     end
   end
 end


### PR DESCRIPTION
Updated descriptions rake task so that it will not impact the 'updated at' field for saved scenarios.

(Also cleaned up the session store)