### PR TITLE
Migration to remove the tmp description column 

### DIFF
--- a/db/migrate/20250129082945_remove_tmp_description_saved_scenarios.rb
+++ b/db/migrate/20250129082945_remove_tmp_description_saved_scenarios.rb
@@ -1,0 +1,5 @@
+class RemoveTmpDescriptionSavedScenarios < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :saved_scenarios, :tmp_description, :text
+  end
+end


### PR DESCRIPTION
Migration to remove the tmp description column used in the data migration