### PR TITLE
Fixes for version tag spacing and hovercards

### DIFF
--- a/app/components/collections/row/component.html.erb
+++ b/app/components/collections/row/component.html.erb
@@ -21,8 +21,8 @@
           </span>
         <% end %>
       </div>
+      <span class="text-midnight-400">  #<%= @collection.version.tag %></span>
     </div>
-    <span class="text-midnight-400">  <%= @collection.version.tag %></span>
   </div>
   <span class="text-midnight-400 mx-auto text-sm mt-3">
     Last updated <%= time_ago_in_words(@collection.updated_at) %> ago

--- a/app/components/hovercard/component.html.erb
+++ b/app/components/hovercard/component.html.erb
@@ -1,4 +1,3 @@
-
 <div
   data-controller="hovercard"
   data-hovercard-url-value="<%= @path %>"
@@ -6,15 +5,13 @@
 >
   <%= content %>
 
-  <%# static card %>
-  <%# should make text optional and setup the @path with turbo see: https://boringrails.com/articles/hovercards-stimulus/ %>
+<%# static card %>
+<%# should make text optional and setup the @path with turbo see: https://boringrails.com/articles/hovercards-stimulus/ %>
   <div class="relative opacity-0 transition delay-500 duration-300" data-hovercard-target="card">
-    <div data-tooltip-arrow class="absolute top-0 <%= placement_class %> z-50 shadow-lg rounded-lg p-3 min-w-max-content bg-midnight-300 text-midnight-800">
-      <div class="flex space-x-3 items-center w-48 text-sm">
+    <div data-tooltip-arrow class="absolute top-0 <%= placement_class %> z-50 shadow-lg rounded-lg p-3 min-w-max bg-midnight-300 text-midnight-800">
+      <div class="flex space-x-3 items-center max-w-s text-sm">
         <%= @text %>
       </div>
     </div>
   </div>
 </div>
-
-

--- a/app/components/saved_scenario_user/user_row/component.rb
+++ b/app/components/saved_scenario_user/user_row/component.rb
@@ -8,9 +8,6 @@ module SavedScenarioUser::UserRow
     option :destroyable, default: proc { true }
     option :confirmed, default: proc { true }
 
-    # TODO: Investigate below comment?
-    # thing for rendering action
-
     def css_classes
       @confirmed ? "" : "!text-midnight-450"
     end

--- a/app/components/saved_scenario_user/user_row/component.rb
+++ b/app/components/saved_scenario_user/user_row/component.rb
@@ -8,6 +8,7 @@ module SavedScenarioUser::UserRow
     option :destroyable, default: proc { true }
     option :confirmed, default: proc { true }
 
+    # TODO: Investigate below comment?
     # thing for rendering action
 
     def css_classes
@@ -31,43 +32,6 @@ module SavedScenarioUser::UserRow
         t("saved_scenario_users.confirm_destroy.button")
       else
         t("saved_scenario_users.confirm_destroy.not_possible")
-      end
-    end
-  end
-end
-module SavedScenarioUser::UserRow
-  class Component < ApplicationComponent
-    include Turbo::FramesHelper
-
-    option :user
-    option :destroy_path
-    option :update_path
-    option :destroyable, default: proc { true }
-    option :confirmed, default: proc { true }
-
-    # thing for rendering action
-
-    def css_classes
-      @confirmed ? "" : "!text-midnight-450"
-    end
-
-    def disabled
-      @destroyable ? {} : { disabled: true }
-    end
-
-    def disabled_classes
-      @destroyable ? "text-sm hover:cursor-pointer" : "text-sm bg-none bg-midnight-300 border-midnight-300"
-    end
-
-    def destroy_classes
-      @destroyable ? "" : "!hover:text-midnight-400 !hover:cursor-initial pointer-events-none"
-    end
-
-    def destroy_text
-      if @destroyable
-        t('saved_scenario_users.confirm_destroy.button')
-      else
-        t('saved_scenario_users.confirm_destroy.not_possible')
       end
     end
   end

--- a/app/components/saved_scenarios/row/component.html.erb
+++ b/app/components/saved_scenarios/row/component.html.erb
@@ -7,8 +7,8 @@
         <span><%= t("areas.#{@saved_scenario.area_code}") %></span>
         <span><%= @saved_scenario.end_year %></span>
       </div>
+      <span class="text-midnight-400"> #<%= @saved_scenario.version.tag %></span>
     </div>
-    <span class="text-midnight-400"> #<%= @saved_scenario.version.tag %></span>
   </div>
   <span class="text-midnight-400 mx-auto text-sm mt-3"> Last updated <%= time_ago_in_words(@saved_scenario.updated_at) %> ago </span>
   <div class="ml-auto mr-0 mt-3 text-midnight-400">


### PR DESCRIPTION
I put the version tag at the bottom of each row for saved scenarios and collections, made the hovercards filled and deleted half a class where I found some code which had been doubled by mistake.