### PR TITLE
Aesthetic fixes

### DIFF
--- a/app/components/hovercard/component.html.erb
+++ b/app/components/hovercard/component.html.erb
@@ -5,10 +5,10 @@
 >
   <%= content %>
 
-<%# static card %>
-<%# should make text optional and setup the @path with turbo see: https://boringrails.com/articles/hovercards-stimulus/ %>
-  <div class="relative opacity-0 transition delay-500 duration-300" data-hovercard-target="card">
-    <div data-tooltip-arrow class="absolute top-0 <%= placement_class %> z-50 shadow-lg rounded-lg p-3 min-w-max bg-midnight-300 text-midnight-800">
+  <%# static card %>
+  <%# should make text optional and setup the @path with turbo see: https://boringrails.com/articles/hovercards-stimulus/ %>
+  <div class="relative hidden opacity-0 pointer-events-none transition delay-500 duration-300" data-hovercard-target="card">
+    <div data-tooltip-arrow class="absolute top-0 <%= placement_class %> z-10 shadow-lg rounded-lg p-3 min-w-max bg-midnight-300 text-midnight-800">
       <div class="flex space-x-3 items-center max-w-s text-sm">
         <%= @text %>
       </div>

--- a/app/components/saved_scenarios/row/component.html.erb
+++ b/app/components/saved_scenarios/row/component.html.erb
@@ -1,8 +1,10 @@
 <%= link_to @path, data: { turbo_frame: "_top" }, class: "grid grid-cols-4 w-full transition mb-5 p-2 pr-4 rounded-md hover:bg-midnight-600" do %>
   <div class="flex col-span-2">
-    <span class="bg-midnight-900 rounded-md h-8 w-8 mr-5 pt-1 mt-1 text-center text-midnight-200"><%= initials_for(first_owner) %></span>
-    <div class="flex flex-col">
-      <span><%= @saved_scenario.title %></span>
+    <span class="bg-midnight-900 rounded-md h-8 w-8 mr-5 pt-1 mt-1 text-center text-midnight-200 flex-none"><%= initials_for(first_owner) %></span>
+    <div class="flex flex-col flex-1">
+      <div class="flex items-center flex-1 w-full">
+        <span class= "max-w-full truncate overflow-hidden flex-1"><%= @saved_scenario.title %></span>
+      </div>
       <div class="text-sm text-midnight-400">
         <span><%= t("areas.#{@saved_scenario.area_code}") %></span>
         <span><%= @saved_scenario.end_year %></span>
@@ -10,7 +12,9 @@
       <span class="text-midnight-400"> #<%= @saved_scenario.version.tag %></span>
     </div>
   </div>
-  <span class="text-midnight-400 mx-auto text-sm mt-3"> Last updated <%= time_ago_in_words(@saved_scenario.updated_at) %> ago </span>
+  <div class="flex col-span-2">
+    <span class="text-midnight-400 text-sm mr-auto"> Last updated <%= time_ago_in_words(@saved_scenario.updated_at) %> ago</span>
+  </div>
   <div class="ml-auto mr-0 mt-3 text-midnight-400">
     <% if @saved_scenario.private %>
       <%= render(Hovercard::Component.new(path: '', text: t('scenario.private'))) do %>

--- a/app/javascript/controllers/hovercard_controller.js
+++ b/app/javascript/controllers/hovercard_controller.js
@@ -6,10 +6,11 @@ export default class extends Controller {
 
   show() {
     if (this.hasCardTarget) {
-      this.cardTarget.classList.add("delay-500");
-      this.cardTarget.classList.remove("hidden");
-      this.cardTarget.classList.add("opacity-100");
-      this.cardTarget.classList.remove("opacity-0");
+      setTimeout(() => {
+        this.cardTarget.classList.remove("hidden", "pointer-events-none");
+        this.cardTarget.classList.add("opacity-100");
+        this.cardTarget.classList.remove("opacity-0");
+      }, 150);
     } else {
       fetch(this.urlValue)
         .then((r) => r.text())
@@ -25,10 +26,11 @@ export default class extends Controller {
 
   hide() {
     if (this.hasCardTarget) {
-      this.cardTarget.classList.add("opacity-0");
-      this.cardTarget.classList.remove("delay-500");
+      this.cardTarget.classList.add("opacity-0", "pointer-events-none");
       this.cardTarget.classList.remove("opacity-100");
-      this.cardTarget.classList.add("hidden");
+      setTimeout(() => {
+        this.cardTarget.classList.add("hidden");
+      }, 300);
     }
   }
 
@@ -38,4 +40,3 @@ export default class extends Controller {
     }
   }
 }
-

--- a/app/views/saved_scenario_history/index.html.erb
+++ b/app/views/saved_scenario_history/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title) { "#{@saved_scenario.title} <% #{t('meta.name')}" } %>
+<% content_for(:title) { "#{@saved_scenario.title}" } %>
 <% content_for :menu_title, @saved_scenario.localized_title(I18n.locale) %>
 <%= render(partial: "saved_scenarios/block_right_menu", locals: { saved_scenario: @saved_scenario }) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,7 +122,7 @@ en:
         Click the 'Invite others' button to give someone access to your scenario,
         or use the table above to manage users that are already coupled. <br/><br/>
         See the
-        <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/managing-scenarios/scenario-access-management/" target=\"_blank\">
+        <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/user_manual/managing-scenarios/scenario-manage-access/" target=\"_blank\">
         documentation</a> for more information.
       invite: 'Invite others'
       send_invite: Send invite
@@ -163,7 +163,7 @@ en:
     description: |
       Here you can see the history of your saved scenario. A description can be added to each historical version.
       When you are owner of this scenario, you can reset the scenario to an older stage. See the
-      <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/managing-scenarios/scenario-version-history" target=\"_blank\">
+      <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/user_manual/managing-scenarios/scenario-version-history" target=\"_blank\">
       documentation</a> for more information.
     title: History
     error: Something went wrong updating the history of your scenario
@@ -177,6 +177,7 @@ en:
           Edit the description of this saved version. Save your notes on what you have changed.
         restore_description: |
           Restore the saved scenario to this version. This action is irreversible.
+    empty_message: No description
   saved_scenarios:
     title: Saved scenarios
     empty: You don't have any scenarios.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -106,7 +106,7 @@ nl:
         Klik op 'Anderen uitnodigen' om iemand toegang te geven tot jouw scenario of
         gebruik bovenstaande tabel om gekoppelde gebruikers te beheren.<br/><br/>
         Zie de
-        <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/managing-scenarios/scenario-access-management/" target=\"_blank\">
+        <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/user_manual/managing-scenarios/scenario-access-management/" target=\"_blank\">
         documentatie</a> voor meer informatie.
       invite: 'Anderen uitnodigen'
       send_invite: Stuur uitnodiging
@@ -148,7 +148,7 @@ nl:
     description: |
       Here you can see the history of your saved scenario. A description can be added to each historical version.
       When you are owner of this scenario, you can reset the scenario to an older stage. See the
-      <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/managing-scenarios/scenario-version-history" target=\"_blank\">
+      <a class="underline hover:text-midnight-800" href="https://docs.energytransitionmodel.com/main/user_manual/managing-scenarios/scenario-version-history" target=\"_blank\">
       documentation</a> for more information.
     title: History
     error: Something went wrong updating the history of your scenario
@@ -162,6 +162,7 @@ nl:
           Edit the description of this saved version. Save your notes on what you have changed.
         restore_description: |
           Restore the saved scenario to this version. This action is irreversible.
+    empty_message: Geen beschrijving
   saved_scenarios:
     title: Opgeslagen scenario's
     empty: Je hebt nog geen scenario's.


### PR DESCRIPTION
This PR:
- Updates the saved scenario rows so the updated at is nicely aligned, the initial never gets 'squashed' and the version tag matches the area exactly in style
- Updates the links to the docs where relevant to match the new structure of the docs
- Adjusts the hovercards stimulus to make sure the hovercards don't interfere with pressing buttons