### PR TITLE
Updates to config for collections

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -74,8 +74,10 @@ class CollectionsController < ApplicationController
   #
   # POST /collections/create_transition
   def create_transition
+    version = Version.find_by(tag: create_transition_params[:version]) || Version.default
+
     result = CreateInterpolatedCollection.call(
-      engine_client(Version.find_by(tag: create_transition_params[:version])),
+      engine_client(version),
       current_user.saved_scenarios.find(create_transition_params[:saved_scenario_ids]),
       current_user
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,8 @@ module ApplicationHelper
       etengine_url: etengine_url,
       etmodel_url: Settings.etmodel.uri || "http://YOUR_ETMODEL_URL",
       collections_url: Settings.collections.uri || "http://YOUR_COLLECTIONS_URL",
-      etengine_uid: Doorkeeper::Application.find_by(uri: etengine_url)&.uid || "YOUR_ETEngine_ID"
+      etengine_uid: Doorkeeper::Application.find_by(uri: etengine_url)&.uid || "YOUR_ETEngine_ID",
+      nextauth_secret: SecureRandom.hex(32)
     ))
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,6 @@ module ApplicationHelper
       etengine_url: etengine_url,
       etmodel_url: Settings.etmodel.uri || "http://YOUR_ETMODEL_URL",
       collections_url: Settings.collections.uri || "http://YOUR_COLLECTIONS_URL",
-      etengine_uid: Doorkeeper::Application.find_by(uri: etengine_url)&.uid || "YOUR_ETEngine_ID",
       nextauth_secret: SecureRandom.hex(32)
     ))
   end

--- a/lib/myetm/staff_applications.rb
+++ b/lib/myetm/staff_applications.rb
@@ -89,6 +89,7 @@
 
               # Authentication.
               NEXTAUTH_URL=%<collections_url>s
+              NEXTAUTH_SECRET=%<nextauth_secret>s
               AUTH_CLIENT_ID=%<uid>s
               AUTH_CLIENT_SECRET=%<secret>s
               ETENGINE_CLIENT_ID=%<etengine_uid>s

--- a/lib/myetm/staff_applications.rb
+++ b/lib/myetm/staff_applications.rb
@@ -92,7 +92,6 @@
               NEXTAUTH_SECRET=%<nextauth_secret>s
               AUTH_CLIENT_ID=%<uid>s
               AUTH_CLIENT_SECRET=%<secret>s
-              ETENGINE_CLIENT_ID=%<etengine_uid>s
             ENV
           )
         end


### PR DESCRIPTION
The version wasn't always getting set correctly in the create_transition method so I've added a fallback.

I also added a NEXTAUTH_SECRET to the config for the .env for staff applications. This is just a randomly generated secret - I think we will need to set this up via Netlify as well to get the authorization working, but it does work locally like this.

Goes with [this PR](https://github.com/quintel/multi-year-charts/pull/85) on collections.