### PR TITLE
Let ETModel know to check for possible sign in on load

### DIFF
--- a/app/components/saved_scenarios/info/component.rb
+++ b/app/components/saved_scenarios/info/component.rb
@@ -6,11 +6,14 @@ module SavedScenarios::Info
     option :saved_scenario
     option :time
     option :button_title
+    option :with_user
 
     def link_to_scenario
       params = {
         scenario_id: @saved_scenario.scenario_id,
-        title: @saved_scenario.title
+        title: @saved_scenario.title,
+        # Let's etmodel know to check for signing in
+        current_user: @with_user
       }
 
       "#{@path}?#{params.to_query}"

--- a/app/views/saved_scenarios/show.html.haml
+++ b/app/views/saved_scenarios/show.html.haml
@@ -2,7 +2,7 @@
 - content_for :title, "#{@saved_scenario.localized_title(I18n.locale)} - #{t('saved_scenarios.title')} - #{t('meta.title')}"
 = render(partial: "block_right_menu", locals: { saved_scenario: @saved_scenario })
 
-= render(SavedScenarios::Info::Component.new(path: "#{@saved_scenario.version.model_url}/saved_scenarios/#{@saved_scenario.id}/load", button_title: t('saved_scenarios.open'), saved_scenario: @saved_scenario, time: time_ago_in_words(@saved_scenario.updated_at)))
+= render(SavedScenarios::Info::Component.new(path: "#{@saved_scenario.version.model_url}/saved_scenarios/#{@saved_scenario.id}/load", button_title: t('saved_scenarios.open'), saved_scenario: @saved_scenario, time: time_ago_in_words(@saved_scenario.updated_at), with_user: current_user.present?))
 
 - if flash[:undo_params]
   = render(NoticeBanner::Component.new(path: flash[:undo_params], text: notice_message, button_text: "#{t('undo')}?"))


### PR DESCRIPTION
Adds an extra param to the load request to etmodel, telling it if a user was logged in in myETM