### PR TITLE
Allow admins to manage all resources

### DIFF
--- a/app/models/api/token_ability.rb
+++ b/app/models/api/token_ability.rb
@@ -8,6 +8,11 @@ module Api
     def initialize(token, user)
       scopes = extract_scopes(token)
 
+      if user&.admin?
+        can :manage, :all
+       return
+      end
+
       can :read, SavedScenario, private: false
 
       # scenarios:read

--- a/app/models/api/token_ability.rb
+++ b/app/models/api/token_ability.rb
@@ -10,9 +10,12 @@ module Api
       @user   = user
 
       allow_public_read
-      allow_read if read_scope?
-      allow_write if write_scope?
-      allow_delete if delete_scope?
+      return unless read_scope?
+      allow_read
+      return unless write_scope?
+      allow_write
+      return unless delete_scope?
+      allow_delete
     end
 
     private

--- a/app/models/api/token_ability.rb
+++ b/app/models/api/token_ability.rb
@@ -6,50 +6,13 @@ module Api
     include CanCan::Ability
 
     def initialize(token, user)
-      scopes = extract_scopes(token)
+      @scopes = extract_scopes(token)
+      @user   = user
 
-      if user&.admin?
-        can :manage, :all
-       return
-      end
-
-      can :read, SavedScenario, private: false
-
-      # scenarios:read
-      # --------------
-
-      return unless scopes.include?("scenarios:read")
-
-      can :read, SavedScenario,
-        id: SavedScenarioUser.where(user_id: user.id, role_id: User::Roles.index_of(:scenario_viewer)..).pluck(:saved_scenario_id)
-
-      can :read, Collection,
-        id: Collection.where(user_id: user.id).pluck(:id)
-
-      # scenarios:write
-      # ---------------
-
-      return unless scopes.include?("scenarios:write")
-
-      can :create, SavedScenario
-      can :create, Collection
-
-      # Self-owned scenario.
-      can :update, SavedScenario,
-        id: SavedScenarioUser.where(user_id: user.id, role_id: User::Roles.index_of(:scenario_collaborator)..).pluck(:saved_scenario_id)
-
-      can :update, Collection,
-        id: Collection.where(user_id: user.id).pluck(:id)
-
-      # scenarios:delete
-      # ----------------
-      return unless scopes.include?("scenarios:delete")
-
-      can :destroy, SavedScenario,
-        id: SavedScenarioUser.where(user_id: user.id, role_id: User::Roles.index_of(:scenario_owner)).pluck(:saved_scenario_id)
-
-      can :destroy, Collection,
-        id: Collection.where(user_id: user.id).pluck(:id)
+      allow_public_read
+      allow_read if read_scope?
+      allow_write if write_scope?
+      allow_delete if delete_scope?
     end
 
     private
@@ -58,10 +21,97 @@ module Api
       if token.respond_to?(:scopes)               # doorkeeper_token
         token.scopes
       elsif token.is_a?(Hash)
-        token[:scopes] || token["scopes"] || []   # decoded_token
+        token[:scopes] || token["scopes"] || []
       else
         []
       end
+    end
+
+    def read_scope?
+      @scopes.include?("scenarios:read")
+    end
+
+    def write_scope?
+      @scopes.include?("scenarios:write")
+    end
+
+    def delete_scope?
+      @scopes.include?("scenarios:delete")
+    end
+
+    def admin?
+      @user&.admin?
+    end
+
+    # Everyone can read public saved scenarios.
+    def allow_public_read
+      can :read, SavedScenario, private: false
+    end
+
+    # Allow reading saved scenarios and collections if the token has the read scope.
+    def allow_read
+      if admin?
+        # Admins with read scope can read all saved scenarios and collections.
+        can :read, SavedScenario
+        can :read, Collection
+      else
+        can :read, SavedScenario, id: viewer_saved_scenario_ids
+        can :read, Collection, id: user_collection_ids
+      end
+    end
+
+    # Allow creating and updating saved scenarios and collections if the token has the write scope.
+    def allow_write
+      can :create, SavedScenario
+      can :create, Collection
+
+      if admin?
+        # Admins with write scope can update all saved scenarios and collections.
+        can :update, SavedScenario
+        can :update, Collection
+      else
+        can :update, SavedScenario, id: collaborator_saved_scenario_ids
+        can :update, Collection, id: user_collection_ids
+      end
+    end
+
+    # Allow destroying saved scenarios and collections if the token has the delete scope.
+    def allow_delete
+      if admin?
+        can :destroy, SavedScenario
+        can :destroy, Collection
+      else
+        can :destroy, SavedScenario, id: owner_saved_scenario_ids
+        can :destroy, Collection, id: user_collection_ids
+      end
+    end
+
+    # Helper methods to fetch associated IDs for SavedScenario based on the user's role.
+
+    def viewer_saved_scenario_ids
+      SavedScenarioUser.where(
+        user_id: @user.id,
+        role_id: User::Roles.index_of(:scenario_viewer)..
+      ).pluck(:saved_scenario_id)
+    end
+
+    def collaborator_saved_scenario_ids
+      SavedScenarioUser.where(
+        user_id: @user.id,
+        role_id: User::Roles.index_of(:scenario_collaborator)..
+      ).pluck(:saved_scenario_id)
+    end
+
+    def owner_saved_scenario_ids
+      SavedScenarioUser.where(
+        user_id: @user.id,
+        role_id: User::Roles.index_of(:scenario_owner)
+      ).pluck(:saved_scenario_id)
+    end
+
+    # Helper method for fetching Collection IDs for the user.
+    def user_collection_ids
+      Collection.where(user_id: @user.id).pluck(:id)
     end
   end
 end

--- a/spec/models/api/token_ability_spec.rb
+++ b/spec/models/api/token_ability_spec.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe Api::TokenAbility do
+  # The token scopes will be overridden per context.
+  let(:scopes) { "" }
+  let(:token)  { { "scopes" => scopes } }
+  subject(:ability) { described_class.new(token, user) }
+
+  let(:public_saved_scenario)        { create(:saved_scenario, private: false) }
+  let(:private_saved_scenario)       { create(:saved_scenario, private: true) }
+  let(:other_public_saved_scenario)  { create(:saved_scenario, private: false) }
+  let(:other_private_saved_scenario) { create(:saved_scenario, private: true) }
+
+  let(:user_collection)  { create(:collection, user: user) }
+  let(:other_collection) { create(:collection) }
+
+  # Associated users with specific roles for permission testing.
+  let(:viewer_user)       { create(:user) }
+  let(:collaborator_user) { create(:user) }
+  let(:owner_user)        { create(:user) }
+
+  before do
+    # For viewer: associate viewer_user with private_saved_scenario as viewer.
+    create(:saved_scenario_user,
+           user: viewer_user,
+           saved_scenario: private_saved_scenario,
+           role_id: User::Roles.index_of(:scenario_viewer))
+    # For collaborator:
+    # Associate collaborator_user with public_saved_scenario as collaborator (for write).
+    create(:saved_scenario_user,
+           user: collaborator_user,
+           saved_scenario: public_saved_scenario,
+           role_id: User::Roles.index_of(:scenario_collaborator))
+    # Also associate collaborator_user with private_saved_scenario so they inherit viewer rights.
+    create(:saved_scenario_user,
+           user: collaborator_user,
+           saved_scenario: private_saved_scenario,
+           role_id: User::Roles.index_of(:scenario_collaborator))
+    # For owner:
+    # Associate owner_user with private_saved_scenario as owner (for delete).
+    create(:saved_scenario_user,
+           user: owner_user,
+           saved_scenario: private_saved_scenario,
+           role_id: User::Roles.index_of(:scenario_owner))
+    # Also associate owner_user with public_saved_scenario as collaborator so they have update rights.
+    create(:saved_scenario_user,
+           user: owner_user,
+           saved_scenario: public_saved_scenario,
+           role_id: User::Roles.index_of(:scenario_collaborator))
+  end
+
+  context 'when the token scope is "public" (no scopes)' do
+    let(:user) { create(:user, admin: false) }
+    let(:scopes) { "" }
+    before { user_collection }
+
+    describe "read abilities" do
+      it "allows reading public saved scenarios" do
+        expect(ability).to be_able_to(:read, public_saved_scenario)
+        expect(ability).to be_able_to(:read, other_public_saved_scenario)
+      end
+
+      it "does not allow reading private saved scenarios" do
+        expect(ability).not_to be_able_to(:read, private_saved_scenario)
+        expect(ability).not_to be_able_to(:read, other_private_saved_scenario)
+      end
+
+      it "does not allow reading any collections" do
+        expect(ability).not_to be_able_to(:read, user_collection)
+        expect(ability).not_to be_able_to(:read, other_collection)
+      end
+    end
+
+    describe "write abilities" do
+      it "does not allow creating or updating saved scenarios" do
+        expect(ability).not_to be_able_to(:create, SavedScenario)
+        expect(ability).not_to be_able_to(:update, public_saved_scenario)
+      end
+
+      it "does not allow creating or updating collections" do
+        expect(ability).not_to be_able_to(:create, Collection)
+        expect(ability).not_to be_able_to(:update, user_collection)
+      end
+    end
+
+    describe "delete abilities" do
+      it "does not allow destroying any saved scenario" do
+        expect(ability).not_to be_able_to(:destroy, public_saved_scenario)
+        expect(ability).not_to be_able_to(:destroy, private_saved_scenario)
+      end
+
+      it "does not allow destroying any collection" do
+        expect(ability).not_to be_able_to(:destroy, user_collection)
+      end
+    end
+  end
+
+  context 'when the token scope is "scenarios:read" as a viewer' do
+    let(:user) { viewer_user }
+    let(:scopes) { "scenarios:read" }
+    before { user_collection }
+
+    describe "read abilities" do
+      it "allows reading public saved scenarios" do
+        expect(ability).to be_able_to(:read, public_saved_scenario)
+        expect(ability).to be_able_to(:read, other_public_saved_scenario)
+      end
+
+      it "allows reading private saved scenarios because the user is a viewer" do
+        expect(ability).to be_able_to(:read, private_saved_scenario)
+      end
+
+      it "does not allow reading private saved scenarios without association" do
+        expect(ability).not_to be_able_to(:read, other_private_saved_scenario)
+      end
+
+      it "allows reading collections owned by the user" do
+        expect(ability).to be_able_to(:read, user_collection)
+      end
+
+      it "does not allow reading collections not owned by the user" do
+        expect(ability).not_to be_able_to(:read, other_collection)
+      end
+    end
+
+    describe "write abilities" do
+      it "does not allow creating or updating saved scenarios" do
+        expect(ability).not_to be_able_to(:create, SavedScenario)
+        expect(ability).not_to be_able_to(:update, public_saved_scenario)
+      end
+
+      it "does not allow creating or updating collections" do
+        expect(ability).not_to be_able_to(:create, Collection)
+        expect(ability).not_to be_able_to(:update, user_collection)
+      end
+    end
+
+    describe "delete abilities" do
+      it "does not allow destroying saved scenarios" do
+        expect(ability).not_to be_able_to(:destroy, private_saved_scenario)
+      end
+    end
+  end
+
+  context 'when the token scope is "scenarios:read scenarios:write" as a collaborator' do
+    let(:user) { collaborator_user }
+    let(:scopes) { "scenarios:read scenarios:write" }
+    before { user_collection }
+
+    describe "read abilities" do
+      it "allows reading public saved scenarios" do
+        expect(ability).to be_able_to(:read, public_saved_scenario)
+        expect(ability).to be_able_to(:read, other_public_saved_scenario)
+      end
+
+      it "allows reading private saved scenarios because the user is a collaborator" do
+        expect(ability).to be_able_to(:read, private_saved_scenario)
+      end
+
+      it "does not allow reading private saved scenarios without association" do
+        expect(ability).not_to be_able_to(:read, other_private_saved_scenario)
+      end
+
+      it "allows reading collections owned by the user" do
+        expect(ability).to be_able_to(:read, user_collection)
+      end
+
+      it "does not allow reading collections not owned by the user" do
+        expect(ability).not_to be_able_to(:read, other_collection)
+      end
+    end
+
+    describe "write abilities" do
+      it "allows creating a new saved scenario" do
+        expect(ability).to be_able_to(:create, SavedScenario)
+      end
+
+      it "allows creating a new collection" do
+        expect(ability).to be_able_to(:create, Collection)
+      end
+
+      it "allows updating saved scenarios in collaborator scope" do
+        expect(ability).to be_able_to(:update, public_saved_scenario)
+        expect(ability).to be_able_to(:update, private_saved_scenario)
+      end
+
+      it "does not allow updating saved scenarios not in collaborator scope" do
+        expect(ability).not_to be_able_to(:update, other_public_saved_scenario)
+        expect(ability).not_to be_able_to(:update, other_private_saved_scenario)
+      end
+
+      it "allows updating collections owned by the user" do
+        expect(ability).to be_able_to(:update, user_collection)
+      end
+
+      it "does not allow updating collections not owned by the user" do
+        expect(ability).not_to be_able_to(:update, other_collection)
+      end
+    end
+
+    describe "delete abilities" do
+      it "does not allow destroying saved scenarios" do
+        expect(ability).not_to be_able_to(:destroy, private_saved_scenario)
+      end
+    end
+  end
+
+  context 'when the token scope is "scenarios:read scenarios:write scenarios:delete" as an owner' do
+    let(:user) { owner_user }
+    let(:scopes) { "scenarios:read scenarios:write scenarios:delete" }
+    before { user_collection }
+
+    describe "read abilities" do
+      it "allows reading public saved scenarios" do
+        expect(ability).to be_able_to(:read, public_saved_scenario)
+        expect(ability).to be_able_to(:read, other_public_saved_scenario)
+      end
+
+      it "allows reading private saved scenarios because the user is an owner" do
+        expect(ability).to be_able_to(:read, private_saved_scenario)
+      end
+
+      it "does not allow reading private saved scenarios without association" do
+        expect(ability).not_to be_able_to(:read, other_private_saved_scenario)
+      end
+
+      it "allows reading collections owned by the user" do
+        expect(ability).to be_able_to(:read, user_collection)
+      end
+
+      it "does not allow reading collections not owned by the user" do
+        expect(ability).not_to be_able_to(:read, other_collection)
+      end
+    end
+
+    describe "write abilities" do
+      it "allows creating a new saved scenario" do
+        expect(ability).to be_able_to(:create, SavedScenario)
+      end
+
+      it "allows creating a new collection" do
+        expect(ability).to be_able_to(:create, Collection)
+      end
+
+      it "allows updating saved scenarios in collaborator scope" do
+        expect(ability).to be_able_to(:update, public_saved_scenario)
+        expect(ability).to be_able_to(:update, private_saved_scenario)
+      end
+
+      it "does not allow updating saved scenarios not in collaborator scope" do
+        expect(ability).not_to be_able_to(:update, other_public_saved_scenario)
+        expect(ability).not_to be_able_to(:update, other_private_saved_scenario)
+      end
+
+      it "allows updating collections owned by the user" do
+        expect(ability).to be_able_to(:update, user_collection)
+      end
+
+      it "does not allow updating collections not owned by the user" do
+        expect(ability).not_to be_able_to(:update, other_collection)
+      end
+    end
+
+    describe "delete abilities" do
+      it "allows destroying saved scenarios in owner scope" do
+        expect(ability).to be_able_to(:destroy, private_saved_scenario)
+      end
+
+      it "does not allow destroying saved scenarios not in owner scope" do
+        expect(ability).not_to be_able_to(:destroy, public_saved_scenario)
+        expect(ability).not_to be_able_to(:destroy, other_public_saved_scenario)
+        expect(ability).not_to be_able_to(:destroy, other_private_saved_scenario)
+      end
+
+      it "allows destroying collections owned by the user" do
+        expect(ability).to be_able_to(:destroy, user_collection)
+      end
+
+      it "does not allow destroying collections not owned by the user" do
+        expect(ability).not_to be_able_to(:destroy, other_collection)
+      end
+    end
+  end
+
+  context 'when the user is an admin' do
+    let(:user) { create(:user, admin: true) }
+    let(:scopes) { "scenarios:read scenarios:write scenarios:delete" }
+    before { user_collection }
+
+    describe "read abilities" do
+      it "allows reading all saved scenarios" do
+        expect(ability).to be_able_to(:read, public_saved_scenario)
+        expect(ability).to be_able_to(:read, private_saved_scenario)
+        expect(ability).to be_able_to(:read, other_public_saved_scenario)
+        expect(ability).to be_able_to(:read, other_private_saved_scenario)
+      end
+
+      it "allows reading all collections" do
+        expect(ability).to be_able_to(:read, user_collection)
+        expect(ability).to be_able_to(:read, other_collection)
+      end
+    end
+
+    describe "write abilities" do
+      it "allows updating all saved scenarios" do
+        expect(ability).to be_able_to(:update, public_saved_scenario)
+        expect(ability).to be_able_to(:update, private_saved_scenario)
+        expect(ability).to be_able_to(:update, other_public_saved_scenario)
+        expect(ability).to be_able_to(:update, other_private_saved_scenario)
+      end
+
+      it "allows updating all collections" do
+        expect(ability).to be_able_to(:update, user_collection)
+        expect(ability).to be_able_to(:update, other_collection)
+      end
+    end
+
+    describe "delete abilities" do
+      it "allows destroying all saved scenarios" do
+        expect(ability).to be_able_to(:destroy, public_saved_scenario)
+        expect(ability).to be_able_to(:destroy, private_saved_scenario)
+        expect(ability).to be_able_to(:destroy, other_public_saved_scenario)
+        expect(ability).to be_able_to(:destroy, other_private_saved_scenario)
+      end
+
+      it "allows destroying all collections" do
+        expect(ability).to be_able_to(:destroy, user_collection)
+        expect(ability).to be_able_to(:destroy, other_collection)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Goes with [this PR for ETEngine](https://github.com/quintel/etengine/pull/1511).

EDIT: Should I just remove current ability and token ability from MyETM? At the moment cancancan is only used within the engine to manage access to resources, I don't think it's used at all in MyETM.

Closes #110