### PR TITLE
Set version on interpolated collection

### DIFF
--- a/app/services/create_interpolated_collection.rb
+++ b/app/services/create_interpolated_collection.rb
@@ -52,6 +52,7 @@ class CreateInterpolatedCollection
 
   def create_collection
     collection = Collection.new_from_saved_scenario(@saved_scenario, user: @user)
+    collection.version ||= @saved_scenario.version || Version.default
 
     scenarios.each do |sresult|
       collection.scenarios.build(scenario_id: sresult.value['id'])

--- a/spec/services/create_interpolated_collection_spec.rb
+++ b/spec/services/create_interpolated_collection_spec.rb
@@ -54,6 +54,10 @@ describe CreateInterpolatedCollection, type: :service do
       it 'associates the scenarios with the Collection' do
         expect(result.value.scenarios.count).to be(2)
       end
+
+      it 'sets the version on the Collection based on the saved_scenario' do
+        expect(result.value.version).to eq(scenario.version)
+      end
     end
 
     context 'when ETEngine returns an error for 2030, but not 2040' do


### PR DESCRIPTION
Explicitly set version on collection based on saved scenario when interpolating.

I feel like this should not be necessary because the version is set here?

```
  def self.new_from_saved_scenario(scenario, attrs)
    new({
      area_code: scenario.area_code,
      end_year: scenario.end_year,
      title: scenario.title,
      interpolation: true,
      version: scenario.version,
      saved_scenario_ids: [ scenario.id ]
    }.merge(attrs))
  end
  ```
  
  But it can't hurt to have a fallback I suppose.
  
  Closes #117 