### PR TITLE
Dump n load

### DIFF
--- a/app/controllers/api/v1/featured_scenarios_controller.rb
+++ b/app/controllers/api/v1/featured_scenarios_controller.rb
@@ -18,14 +18,20 @@ module Api
 
       # GET /api/v1/featured_scenarios/scenario_ids
       #
-      # Returns the list of scenario_ids associated with the featured scenarios.
+      # Returns the list of scenario_ids and names associated with the featured scenarios.
       # Used by the dump feature in the Engine
-      def scenario_ids
-        ids = featured_scenarios
-                .includes(:saved_scenario)
-                .map { |f| f.saved_scenario.scenario_id }
+      def scenarios
+        scenarios = featured_scenarios
+                     .includes(:saved_scenario)
+                     .map do |featured_scenario|
+                       saved_scenario = featured_scenario.saved_scenario
+                       {
+                         id: saved_scenario.scenario_id,
+                         title: saved_scenario.title
+                       }
+                     end
 
-        render json: { scenario_ids: ids }, status: :ok
+        render json: { scenarios: scenarios }, status: :ok
       end
 
       private

--- a/app/controllers/api/v1/featured_scenarios_controller.rb
+++ b/app/controllers/api/v1/featured_scenarios_controller.rb
@@ -16,6 +16,18 @@ module Api
         render json: @featured_scenario.as_json, status: :ok
       end
 
+      # GET /api/v1/featured_scenarios/scenario_ids
+      #
+      # Returns the list of scenario_ids associated with the featured scenarios.
+      # Used by the dump feature in the Engine
+      def scenario_ids
+        ids = featured_scenarios
+                .includes(:saved_scenario)
+                .map { |f| f.saved_scenario.scenario_id }
+
+        render json: { scenario_ids: ids }, status: :ok
+      end
+
       private
 
       # Find a single FeaturedScenario for the `show` action

--- a/app/controllers/api/v1/featured_scenarios_controller.rb
+++ b/app/controllers/api/v1/featured_scenarios_controller.rb
@@ -31,7 +31,7 @@ module Api
                        }
                      end
 
-        render json: { scenarios: scenarios }, status: :ok
+        render json: scenarios, status: :ok
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,9 @@ Rails.application.routes.draw do
           end
         end
       end
-      resources :featured_scenarios, only: %i[index show]
+      resources :featured_scenarios, only: %i[index show] do
+        collection { get :scenario_ids }
+      end
       resources :versions, only: [:index]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,7 +92,7 @@ Rails.application.routes.draw do
         end
       end
       resources :featured_scenarios, only: %i[index show] do
-        collection { get :scenario_ids }
+        collection { get :scenarios }
       end
       resources :versions, only: [:index]
     end


### PR DESCRIPTION
Goes with [this PR on the engine](https://github.com/quintel/etengine/pull/1593).

This PR adds a 'scenarios' endpoint to the featured scenarios API controller which returns the featured scenarios as an ActiveResource.