### PR TITLE
Migration to retire de and dk datasets for 2015

### DIFF
--- a/db/migrate/20250709122138_retire_dk_de_2015.rb
+++ b/db/migrate/20250709122138_retire_dk_de_2015.rb
@@ -1,0 +1,12 @@
+class RetireDkDe2015 < ActiveRecord::Migration[7.1]
+  def up
+    SavedScenario.where(area_code: ['de', 'dk']).find_each do |scenario|
+      case scenario.area_code
+      when 'de'
+        scenario.update!(area_code: 'DE_germany')
+      when 'dk'
+        scenario.update!(area_code: 'DK_denmark')
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_13_134056) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_09_122138) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long


### PR DESCRIPTION
This migration handles the saved scenarios for de/dk [as required](https://github.com/quintel/my-etm/pull/145#pullrequestreview-2993997581) for [this PR](https://github.com/quintel/my-etm/pull/145).