### PR TITLE
Allow empty collections

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -43,6 +43,8 @@
     @apply bg-midnight-980;
     @apply text-midnight-200;
     @apply hover:bg-midnight-990;
+    @apply disabled:bg-midnight-990;
+    @apply disabled:cursor-default;
   }
 
   .button-success {

--- a/app/javascript/controllers/collections_controller.js
+++ b/app/javascript/controllers/collections_controller.js
@@ -1,15 +1,16 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["scenario", "versionSelect", "checkbox"]
+  static targets = ["scenario", "versionSelect", "checkbox", "saveButton"]
 
   connect() {
-    this.validate()
     this.filterScenarios()
+    this.validate()
   }
 
   versionChanged(event) {
     this.filterScenarios()
+    this.validate()
   }
 
   filterScenarios() {
@@ -32,6 +33,9 @@ export default class extends Controller {
   validate() {
     let checked = this.checkboxTargets.filter((box) => box.checked);
     let unchecked = this.checkboxTargets.filter((box) => !box.checked);
+    if (this.hasSaveButtonTarget) {
+      this.saveButtonTarget.disabled = checked.length === 0;
+    }
     if (checked.length == 6) {
       unchecked.forEach((box) => box.disabled = true);
     } else {

--- a/app/views/collections/new.html.haml
+++ b/app/views/collections/new.html.haml
@@ -27,5 +27,5 @@
 
   .flex.mt-10
     - if @scenarios.present?
-      = f.submit t('scenario.save'), class: 'button button-primary mr-5'
+      = f.submit t('scenario.save'), class: 'button button-primary mr-5', data: { 'collections-target': 'saveButton' }
     = link_to t('collections.new.form.cancel'), collections_path, class: 'button'


### PR DESCRIPTION
There's a design question involved in this bug, because we have to determine whether we want users to be able to create empty collections or not. I think for now there's no harm (or gain) in it, because there's nothing you can really do with them. If one day we enable users to edit their collections and add/remove scenarios then it might be nice to be able to make empty collections.

What do you think @noracato? Otherwise we can of course pass a more helpful error message or not allow the form to be sent if the scenario_ids param is an empty array.

Closes #149