### PR TITLE
Don't include the user id in create scenario users params

### DIFF
--- a/app/services/create_saved_scenario_user.rb
+++ b/app/services/create_saved_scenario_user.rb
@@ -93,7 +93,6 @@ class CreateSavedScenarioUser
 
   def api_user_params
     {
-      user_id: saved_scenario_user.user_id,
       user_email: saved_scenario_user.email,
       role: User::ROLES[saved_scenario_user.role_id]
     }


### PR DESCRIPTION
Create relies on email instead of id, and update can rely on user id.

The motivation of this change is to ensure a clean separation between create and update logic for scenario users. Because the scenario user model in the engine will determine how best to couple existing users as scenario users including the maximum information, passing this extra information is not necessary and may cause a race condition in coupling associated users.

Related to: [this scenario users issue](https://github.com/quintel/etengine/issues/1653) and [this etengine PR](https://github.com/quintel/etengine/pull/1654)