### PR TITLE
Bump pagy to v43, swap countless for numbered pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,9 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     ostruct (0.6.0)
-    pagy (9.3.1)
+    pagy (43.0.4)
+      json
+      yaml
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
@@ -488,6 +490,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yaml (0.4.0)
     zeitwerk (2.6.18)
 
 PLATFORMS

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -213,3 +213,44 @@ form#new_collection .checkbox-wrapper:has(input:checked) {
 form#new_collection .checkbox-wrapper:has(input:checked) span {
   @apply text-midnight-200;
 }
+
+
+/* PAGY */
+@layer components {
+  .pagy {
+    @apply flex space-x-2;
+
+    a:first-child {
+      margin-left: auto;
+    }
+    a:last-child {
+      margin-right: 0;
+    }
+
+    a:not([role="separator"]) { /* all but gaps */
+      @apply block
+        text-sm
+        text-midnight-800
+        rounded-md border
+        border-midnight-940
+        p-2 px-5
+        hover:bg-midnight-940;
+    }
+
+    a[aria-label="Next"], a[aria-label="Previous"] {
+      @apply border-none hover:bg-transparent;
+    }
+
+    a[aria-label="Next"]:not([aria-disabled]), a[aria-label="Previous"]:not([aria-disabled]) {
+      @apply hover:underline;
+    }
+
+    a:not([href]) { /* all but links */
+      @apply cursor-default
+    }
+
+    a[aria-current] {  /* current page */
+      @apply bg-midnight-940;
+    }
+  }
+}

--- a/app/components/more_pagy/component.html.erb
+++ b/app/components/more_pagy/component.html.erb
@@ -1,12 +1,3 @@
-<% if @pagy.next.present? %>
-    <%= button_to t('more'), pagy_url_for(@pagy, @pagy.next),
-      class:"
-        text-sm
-        text-midnight-800
-        rounded-md border
-        border-midnight-940
-        p-2 px-5
-        float-right
-        hover:bg-midnight-940"
-    %>
+<% if @pagy.next.present? || @pagy.previous.present?%>
+  <%== @pagy.series_nav %>
 <% end %>

--- a/app/components/more_pagy/component.rb
+++ b/app/components/more_pagy/component.rb
@@ -1,7 +1,5 @@
 module MorePagy
   class Component < ApplicationComponent
-    include Pagy::Frontend
-
     option :pagy
   end
 end

--- a/app/components/pagy_component.rb
+++ b/app/components/pagy_component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class PagyComponent < ApplicationComponent
-  include Pagy::Frontend
-
   option :pagy_objects, default: proc { nil }
 end

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -1,12 +1,12 @@
 module Admin
   class CollectionsController < ApplicationController
     include AdminController
-    include Pagy::Backend
+    include Pagy::Method
     include Filterable
 
     def index
       # Include Pagy to paginate @collections or any other resource
-      @pagy_collections, @collections = pagy_countless(
+      @pagy_collections, @collections = pagy(
         Collection.kept.order(created_at: :desc)
       )
 
@@ -22,7 +22,7 @@ module Admin
     def list
       filtered = filter!(Collection)
 
-      @pagy_collections, @collections =  pagy_countless(filtered.kept)
+      @pagy_collections, @collections =  pagy(filtered.kept)
 
       respond_to do |format|
         format.html { render(

--- a/app/controllers/admin/saved_scenarios_controller.rb
+++ b/app/controllers/admin/saved_scenarios_controller.rb
@@ -1,12 +1,12 @@
 module Admin
   class SavedScenariosController < ApplicationController
     include AdminController
-    include Pagy::Backend
+    include Pagy::Method
     include Filterable
 
     # GET /admin/saved_scenarios
     def index
-      @pagy_admin_saved_scenarios, @saved_scenarios = pagy_countless(admin_saved_scenarios)
+      @pagy_admin_saved_scenarios, @saved_scenarios = pagy(admin_saved_scenarios)
 
       respond_to do |format|
         format.html

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class UsersController < ApplicationController
     include AdminController
-    include Pagy::Backend
+    include Pagy::Method
     include Filterable
 
     before_action :set_user, only: %i[confirm update edit]
@@ -13,7 +13,7 @@ module Admin
 
     # All users
     def index
-      @pagy_admin_users, @users = pagy_countless(admin_all_users)
+      @pagy_admin_users, @users = pagy(admin_all_users)
 
       respond_to do |format|
         format.html

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CollectionsController < ApplicationController
-  include Pagy::Backend
+  include Pagy::Method
   include Filterable
 
   load_resource only: %i[discard undiscard new_transition create_transition confirm_destroy]
@@ -17,7 +17,7 @@ class CollectionsController < ApplicationController
 
   # GET /collections or /collections.json
   def index
-    @pagy_collections, @collections = pagy_countless(user_collections)
+    @pagy_collections, @collections = pagy(user_collections)
 
     respond_to do |format|
       format.html

--- a/app/controllers/discarded_controller.rb
+++ b/app/controllers/discarded_controller.rb
@@ -1,5 +1,5 @@
 class DiscardedController < ApplicationController
-  include Pagy::Backend
+  include Pagy::Method
   before_action :require_user
 
   def index
@@ -13,7 +13,7 @@ class DiscardedController < ApplicationController
         .discarded.to_a
     ).sort_by(&:updated_at).reverse
 
-    @pagy, @resources = pagy_array(discarded_resources, items: 10)
+    @pagy, @resources = pagy(:offset, discarded_resources, items: 10)
 
     respond_to do |format|
       format.html

--- a/app/controllers/saved_scenarios_controller.rb
+++ b/app/controllers/saved_scenarios_controller.rb
@@ -1,5 +1,5 @@
 class SavedScenariosController < ApplicationController
-  include Pagy::Backend
+  include Pagy::Method
   include Filterable
 
   load_resource only: %i[discard undiscard publish unpublish confirm_destroy]
@@ -18,7 +18,7 @@ class SavedScenariosController < ApplicationController
 
   # GET /saved_scenarios
   def index
-    @pagy_saved_scenarios, @saved_scenarios = pagy_countless(ordered_user_saved_scenarios)
+    @pagy_saved_scenarios, @saved_scenarios = pagy(ordered_user_saved_scenarios)
     @area_codes = area_codes_for_filter
 
     respond_to do |format|

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,220 +1,48 @@
 # frozen_string_literal: true
 
-# Pagy initializer file (9.0.5)
-# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
-# Should you just cherry pick part of this file, please maintain the require-order of the extras
+# Pagy initializer file (43.0.4)
+# See https://ddnexus.github.io/pagy/resources/initializer/
 
-
-# Pagy Variables
-# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
-# You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
-# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
-# Here are the few that make more sense as DEFAULTs:
-Pagy::DEFAULT[:limit]         = 8                   # default
-# Pagy::DEFAULT[:size]        = 7                     # default
-# Pagy::DEFAULT[:ends]        = true                  # default
-# Pagy::DEFAULT[:page_param]  = :page                 # default
-# Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
-# Pagy::DEFAULT[:max_pages]   = 3000                  # example
-
-
-# Extras
-# See https://ddnexus.github.io/pagy/categories/extra
-
-
-# Legacy Compatibility Extras
-
-# Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
-# See https://ddnexus.github.io/pagy/docs/extras/size
-# require 'pagy/extras/size'   # must be required before the other extras
-
-
-# Backend Extras
-
-# Arel extra: For better performance utilizing grouped ActiveRecord collections:
-# See: https://ddnexus.github.io/pagy/docs/extras/arel
-# require 'pagy/extras/arel'
-
-# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
-# See https://ddnexus.github.io/pagy/docs/extras/array
-require 'pagy/extras/array'
-
-# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
-# See https://ddnexus.github.io/pagy/docs/extras/calendar
-# require 'pagy/extras/calendar'
-# Default for each calendar unit class in IRB:
-# >> Pagy::Calendar::Year::DEFAULT
-# >> Pagy::Calendar::Quarter::DEFAULT
-# >> Pagy::Calendar::Month::DEFAULT
-# >> Pagy::Calendar::Week::DEFAULT
-# >> Pagy::Calendar::Day::DEFAULT
+############ Global Options ################################################################
+# See https://ddnexus.github.io/pagy/toolbox/options/ for details.
+# Add your global options below. They will be applied globally.
+# For example:
 #
-# Uncomment the following lines, if you need calendar localization without using the I18n extra
-# module LocalizePagyCalendar
-#   def localize(time, opts)
-#     ::I18n.l(time, **opts)
-#   end
-# end
-# Pagy::Calendar.prepend LocalizePagyCalendar
+Pagy.options[:limit] = 8                  # Limit the items per page
+# Pagy.options[:client_max_limit] = 100   # The client can request a limit up to 100
+# Pagy.options[:max_pages] = 200          # Allow only 200 pages
+# Pagy.options[:jsonapi] = true           # Use JSON:API compliant URLs
+# Pagy.options[:headless] = true
 
-# Countless extra: Paginate without any count, saving one query per rendering
-# See https://ddnexus.github.io/pagy/docs/extras/countless
-require 'pagy/extras/countless'
-Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
-
-# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
-# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
-# Default :pagy_search method: change only if you use also
-# the searchkick or meilisearch extra that defines the same
-# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
-# Default original :search method called internally to do the actual search
-# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
-# require 'pagy/extras/elasticsearch_rails'
-
-# Headers extra: http response headers (and other helpers) useful for API pagination
-# See http://ddnexus.github.io/pagy/extras/headers
-# require 'pagy/extras/headers'
-# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
-#                            limit: 'Page-Items',
-#                            count: 'Total-Count',
-#                            pages: 'Total-Pages' }     # default
-
-# Keyset extra: Paginate with the Pagy keyset pagination technique
-# See http://ddnexus.github.io/pagy/extras/keyset
-# require 'pagy/extras/keyset'
-
-# Meilisearch extra: Paginate `Meilisearch` result objects
-# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
-# Default :pagy_search method: change only if you use also
-# the elasticsearch_rails or searchkick extra that define the same method
-# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
-# Default original :search method called internally to do the actual search
-# Pagy::DEFAULT[:meilisearch_search] = :ms_search
-# require 'pagy/extras/meilisearch'
-
-# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
-# See https://ddnexus.github.io/pagy/docs/extras/metadata
-# you must require the JS Tools internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
-# require 'pagy/extras/js_tools'
-# require 'pagy/extras/metadata'
-# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
-# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
-
-# Searchkick extra: Paginate `Searchkick::Results` objects
-# See https://ddnexus.github.io/pagy/docs/extras/searchkick
-# Default :pagy_search method: change only if you use also
-# the elasticsearch_rails or meilisearch extra that defines the same
-# DEFAULT[:searchkick_pagy_search] = :pagy_search
-# Default original :search method called internally to do the actual search
-# Pagy::DEFAULT[:searchkick_search] = :search
-# require 'pagy/extras/searchkick'
-# uncomment if you are going to use Searchkick.pagy_search
-# Searchkick.extend Pagy::Searchkick
-
-
-# Frontend Extras
-
-# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
-# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
-require 'pagy/extras/bootstrap'
-
-# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
-# See https://ddnexus.github.io/pagy/docs/extras/bulma
-# require 'pagy/extras/bulma'
-
-# Pagy extra: Add the pagy styled versions of the javascript-powered navs
-# and a few other components to the Pagy::Frontend module.
-# See https://ddnexus.github.io/pagy/docs/extras/pagy
-# require 'pagy/extras/pagy'
-
-# Multi size var used by the *_nav_js helpers
-# See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
-# Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
-
-
-# Feature Extras
-
-# Gearbox extra: Automatically change the limit per page depending on the page number
-# See https://ddnexus.github.io/pagy/docs/extras/gearbox
-# require 'pagy/extras/gearbox'
-# set to false only if you want to make :gearbox_extra an opt-in variable
-# Pagy::DEFAULT[:gearbox_extra] = false               # default true
-# Pagy::DEFAULT[:gearbox_limit] = [15, 30, 60, 100]   # default
-
-# Limit extra: Allow the client to request a custom limit per page with an optional selector UI
-# See https://ddnexus.github.io/pagy/docs/extras/limit
-# require 'pagy/extras/limit'
-# set to false only if you want to make :limit_extra an opt-in variable
-# Pagy::DEFAULT[:limit_extra] = false    # default true
-# Pagy::DEFAULT[:limit_param] = :limit   # default
-# Pagy::DEFAULT[:limit_max]   = 100      # default
-
-# Overflow extra: Allow for easy handling of overflowing pages
-# See https://ddnexus.github.io/pagy/docs/extras/overflow
-# require 'pagy/extras/overflow'
-# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
-
-# Trim extra: Remove the page=1 param from links
-# See https://ddnexus.github.io/pagy/docs/extras/trim
-# require 'pagy/extras/trim'
-# set to false only if you want to make :trim_extra an opt-in variable
-# Pagy::DEFAULT[:trim_extra] = false # default true
-
-# Standalone extra: Use pagy in non Rack environment/gem
-# See https://ddnexus.github.io/pagy/docs/extras/standalone
-# require 'pagy/extras/standalone'
-# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
-
-# Jsonapi extra: Implements JSON:API specifications
-# See https://ddnexus.github.io/pagy/docs/extras/jsonapi
-# require 'pagy/extras/jsonapi'   # must be required after the other extras
-# set to false only if you want to make :jsonapi an opt-in variable
-# Pagy::DEFAULT[:jsonapi] = false  # default true
-
-# Rails
-# Enable the .js file required by the helpers that use javascript
-# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_limit_selector_js)
-# See https://ddnexus.github.io/pagy/docs/api/javascript
-
-# With the asset pipeline
-# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
-# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
-
-# I18n
-
-# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
-# See https://ddnexus.github.io/pagy/docs/api/i18n
-# Notice: No need to configure anything in this section if your app uses only "en"
-# or if you use the i18n extra below
+############ JavaScript ####################################################################
+# See https://ddnexus.github.io/pagy/resources/javascript/ for details.
+# Examples for Rails:
+# For apps with an assets pipeline
+# Rails.application.config.assets.paths << Pagy::ROOT.join('javascripts')
 #
-# Examples:
-# load the "de" built-in locale:
-# Pagy::I18n.load(locale: 'de')
+# For apps with a javascript builder (e.g. esbuild, webpack, etc.)
+# javascript_dir = Rails.root.join('app/javascript')
+# Pagy.sync_javascript(javascript_dir, 'pagy.mjs') if Rails.env.development?
+
+
+############# Overriding Pagy::I18n Lookup #################################################
+# Refer to https://ddnexus.github.io/pagy/resources/i18n/ for details.
+# Override the I18n lookup by dropping your custom dictionary in some pagy dir.
+# Example for Rails:
 #
-# load the "de" locale defined in the custom file at :filepath:
-# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+# Pagy::I18n.pathnames << Rails.root.join('config/locales/pagy')
+
+
+############# I18n Gem Translation #########################################################
+# See https://ddnexus.github.io/pagy/resources/i18n/ for details.
 #
-# load the "de", "en" and "es" built-in locales:
-# (the first passed :locale will be used also as the default_locale)
-# Pagy::I18n.load({ locale: 'de' },
-#                 { locale: 'en' },
-#                 { locale: 'es' })
+# Pagy.translate_with_the_slower_i18n_gem!
+
+
+############# Calendar Localization for non-en locales ####################################
+# See https://ddnexus.github.io/pagy/toolbox/paginators/calendar#localization for details.
+# Add your desired locales to the list and uncomment the following line to enable them,
+# regardless of whether you use the I18n gem for translations or not, whether with
+# Rails or not.
 #
-# load the "en" built-in locale, a custom "es" locale,
-# and a totally custom locale complete with a custom :pluralize proc:
-# (the first passed :locale will be used also as the default_locale)
-# Pagy::I18n.load({ locale: 'en' },
-#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
-#                 { locale: 'xyz',  # not built-in
-#                   filepath: 'path/to/pagy-xyz.yml',
-#                   pluralize: lambda{ |count| ... } )
-
-
-# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
-# than the default pagy internal i18n (see above)
-# See https://ddnexus.github.io/pagy/docs/extras/i18n
-# require 'pagy/extras/i18n'
-
-
-# When you are done setting your own default freeze it, so it will not get changed accidentally
-Pagy::DEFAULT.freeze
+# Pagy::Calendar.localize_with_rails_i18n_gem(*your_locales)


### PR DESCRIPTION
I updated pagy as the 'More..' button was not working anymore.

Also took the liberty to switch back to numbered pages, as requested by various team members over the last months

<img width="2692" height="1774" alt="Screenshot 2025-11-14 at 11 31 04" src="https://github.com/user-attachments/assets/bf10d6fb-3a63-4ce0-bd5e-885af0b6e23e" />

Closes #193 
