### PR TITLE
Minimal fix for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "3002:3000"
     volumes:
       - .:/app:cached
       - bundle:/usr/local/bundle


### PR DESCRIPTION
## Description
While there are more improvements to be made to the docker-compose and Dockerfile, this minimal change enables users to run the ETM with Docker locally again.

Closes #118 
