### PR TITLE
Fix for saved scenario collaboration

### DIFF
--- a/app/services/create_saved_scenario_user.rb
+++ b/app/services/create_saved_scenario_user.rb
@@ -93,7 +93,6 @@ class CreateSavedScenarioUser
 
   def api_user_params
     {
-      user_id: saved_scenario_user.user_id,
       user_email: saved_scenario_user.email,
       role: User::ROLES[saved_scenario_user.role_id]
     }


### PR DESCRIPTION
## Description
Don't send the user id along with their email when creating a saved scenario user - ETEngine doesn't know how to handle it!

## Related Issues
[See this related ETModel issue](https://github.com/quintel/etmodel/pull/4607)