### PR TITLE
Make the interpolated collection validation accept exactly one saved scenario.

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -176,10 +176,10 @@ class Collection < ApplicationRecord
   end
 
   def validate_interpolated
-    # Ensure interpolated collections (AKA transition paths) have no saved scenarios
+    # Ensure interpolated collections (AKA transition paths) have one saved scenario
     active_saved_scenarios = collection_saved_scenarios.reject(&:marked_for_destruction?)
-    if self.interpolated? && active_saved_scenarios.size > 1
-      errors.add(:scenarios, "interpolated collections cannot have more than 1 saved scenario")
+    if self.interpolated? && active_saved_scenarios.size != 1
+      errors.add(:scenarios, "interpolated collections must have exactly 1 saved scenario")
     end
   end
 

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -7,17 +7,28 @@ FactoryBot.define do
     title { 'My Collection' }
     end_year { 2050 }
     version { Version.find_by(tag: "latest") }
+    interpolation { false }
 
     transient do
       scenarios_count { 2 }
+      saved_scenarios_count { interpolation ? 1 : 0 }
     end
 
-    after(:create) do |myc, evaluator|
-      create_list(
-        :collection_scenario,
-        evaluator.scenarios_count,
-        collection: myc
-      )
+    after(:build) do |collection, evaluator|
+      evaluator.scenarios_count.times do
+        collection.scenarios << build(
+          :collection_scenario,
+          collection: collection
+        )
+      end
+
+      evaluator.saved_scenarios_count.times do
+        collection.collection_saved_scenarios << build(
+          :collection_saved_scenario,
+          collection: collection,
+          user: collection.user
+        )
+      end
     end
   end
 

--- a/spec/factories/collection_saved_scenario.rb
+++ b/spec/factories/collection_saved_scenario.rb
@@ -2,7 +2,11 @@
 
 FactoryBot.define do
   factory :collection_saved_scenario do
-    saved_scenario
+    transient do
+      user { nil }
+    end
+    
+    saved_scenario { create(:saved_scenario, user: user) }
     collection
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Collection, type: :model do
 
   describe 'number of scenarios' do
     let(:user) { create(:user) }
-    let(:myc) { create(:collection, user: user, scenarios_count: 7) }
+    let(:myc) { create(:collection, user: user, scenarios_count: 6) }
 
     context 'with more than 6 combined scenarios' do
       before do
@@ -77,7 +77,7 @@ RSpec.describe Collection, type: :model do
       end
 
       it 'is not valid' do
-        expect(myc).not_to be_valid
+        expect(myc.reload).not_to be_valid
       end
     end
   end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -151,7 +151,8 @@ RSpec.describe "API::Collections", type: :request, api: true do
         end_year: 2050,
         scenario_ids: [1, 2, 3],
         title: 'My collection',
-        version: Version.default.tag
+        version: Version.default.tag,
+        interpolation: false
       }
     end
 
@@ -440,7 +441,7 @@ RSpec.describe "API::Collections", type: :request, api: true do
       it 'does not insert a saved_scenario' do
         expect { request }.not_to change { collection.reload.latest_scenario_ids }
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)['scenarios']).to include('interpolated collections cannot have more than 1 saved scenario')
+        expect(JSON.parse(response.body)['scenarios']).to include('interpolated collections must have exactly 1 saved scenario')
       end
     end
 

--- a/spec/services/api/create_collection_spec.rb
+++ b/spec/services/api/create_collection_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Api::CreateCollection do
       area_code: 'nl2019',
       end_year: 2050,
       scenario_ids: [10, 20],
-      version: Version.default.tag
+      version: Version.default.tag,
+      interpolation: false
     }
   end
 


### PR DESCRIPTION
## Description

Changed the validation in the collection model from accepting zero or one saved scenarios when being interpolated to accepting exactly one saved scenario.
In addition the RSpec factory for the collection some specs were updated to accommodate for this stricter validation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #202
