### PR TITLE
Include description in json serialization for saved scenarios

### DIFF
--- a/app/models/saved_scenario.rb
+++ b/app/models/saved_scenario.rb
@@ -99,6 +99,7 @@ class SavedScenario < ApplicationRecord
     json.merge(
       "version" => version.tag,
       "title" => localized_title(:en),
+      "description" => description.to_plain_text.presence,
       "saved_scenario_users" => saved_scenario_users.map { |u| u.as_json(only: %i[user_id role]) }
     )
   end


### PR DESCRIPTION
## Description
This very minor change also returns the description as plain text as part of the json response for saved scenarios.
Goes with [this pyetm PR](https://github.com/quintel/pyetm/pull/104) to close [this issue](https://github.com/quintel/pyetm/issues/103) 
