### PR TITLE
Enqueue callbacks on create, handle privacy, spec

### DIFF
--- a/app/jobs/saved_scenario_callbacks_job.rb
+++ b/app/jobs/saved_scenario_callbacks_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Enqueues ETEngine callbacks after a SavedScenario is created/updated.
+# Delegates to SavedScenario::PerformEngineCallbacks for the actual work.
+class SavedScenarioCallbacksJob < ApplicationJob
+  queue_as :default
+
+  def perform(scenario_id, user_id, version_tag,
+    operations = [ :protect, :set_roles, :tag_version ])
+    user = User.find(user_id)
+    version = Version.find_by(tag: version_tag) || Version.default
+    http_client = MyEtm::Auth.engine_client(user, version)
+
+    SavedScenario::PerformEngineCallbacks.call(
+      http_client,
+      scenario_id,
+      operations: operations.map(&:to_sym)
+    )
+  end
+end

--- a/app/services/saved_scenario/perform_engine_callbacks.rb
+++ b/app/services/saved_scenario/perform_engine_callbacks.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Performs ETEngine callbacks for a SavedScenario.
+#
+# Supports the following operations:
+# - :protect     - Keep the scenario compatible
+# - :set_roles   - Set scenario roles to preset
+# - :tag_version - Tag the scenario version
+# - :unprotect   - Remove protection from scenario
+#
+# Returns a ServiceResult.
+class SavedScenario::PerformEngineCallbacks
+  extend Dry::Initializer
+  include Service
+
+  param :http_client
+  param :scenario_id
+  option :operations, default: proc { [ :protect, :set_roles, :tag_version ] }
+
+  def call
+    operations.each { |op| perform_operation(op) }
+    ServiceResult.success
+  end
+
+  private
+
+  def perform_operation(operation)
+    case operation
+    when :protect
+      ApiScenario::SetCompatibility.keep_compatible(http_client, scenario_id)
+    when :set_roles
+      ApiScenario::SetRoles.to_preset(http_client, scenario_id)
+    when :tag_version
+      ApiScenario::VersionTags::Create.call(http_client, scenario_id, "")
+    when :unprotect
+      ApiScenario::SetCompatibility.unprotect(http_client, scenario_id)
+    end
+  end
+end

--- a/spec/services/saved_scenario/create_spec.rb
+++ b/spec/services/saved_scenario/create_spec.rb
@@ -71,5 +71,33 @@ describe SavedScenario::Create, type: :service do
         expect(result.value.private).to be_truthy
       end
     end
+
+    context 'when private is explicitly set to false in params' do
+      let(:params) { { scenario_id: 1, area_code: :nl2019, end_year: 2050, title: 'Hey', private: false } }
+
+      before { user.update(private_scenarios: true) }
+
+      it 'sets the provided private parameter' do
+        expect(result.value.private).to be_falsey
+      end
+
+      it 'does not use the users default privacy setting' do
+        expect(result.value.private).not_to eq(user.private_scenarios)
+      end
+    end
+
+    context 'when private is explicitly set to true in params' do
+      let(:params) { { scenario_id: 1, area_code: :nl2019, end_year: 2050, title: 'Hey', private: true } }
+
+      before { user.update(private_scenarios: false) }
+
+      it 'sets the provided private parameter' do
+        expect(result.value.private).to be_truthy
+      end
+
+      it 'does not use the users default privacy setting' do
+        expect(result.value.private).not_to eq(user.private_scenarios)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
To avoid authorization locks and delayed calls, enqueue callbacks on saved scenario create endpoint. This pattern can be re-used for other saved scenario api endpoints such as upsert to ensure quick responses and avoid request hangups.

Goes with this [Engine PR](https://github.com/quintel/etengine/pull/1682) and this [pyetm PR](https://github.com/quintel/pyetm/pull/107).
