### PR TITLE
Change inline email header logo to png format

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -79,7 +79,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%=I18n.t('meta.title')%></h2>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -79,7 +79,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%=I18n.t('meta.title')%></h2>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -79,7 +79,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%= I18n.t('meta.title') %></h2>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -82,7 +82,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%=I18n.t('meta.title')%></h2>

--- a/app/views/identity/token_mailer/created_token.html.erb
+++ b/app/views/identity/token_mailer/created_token.html.erb
@@ -83,7 +83,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%=I18n.t('meta.title')%></h2>

--- a/app/views/identity/token_mailer/expiring_token.html.erb
+++ b/app/views/identity/token_mailer/expiring_token.html.erb
@@ -83,7 +83,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%=I18n.t('meta.title')%></h2>

--- a/app/views/scenario_invitation_mailer/scenario_invitation.en.html.erb
+++ b/app/views/scenario_invitation_mailer/scenario_invitation.en.html.erb
@@ -99,7 +99,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%=I18n.t('meta.title')%></h2>

--- a/app/views/scenario_invitation_mailer/scenario_invitation.nl.html.erb
+++ b/app/views/scenario_invitation_mailer/scenario_invitation.nl.html.erb
@@ -99,7 +99,7 @@
   <div class="container">
     <div class="header">
       <div class="logo-container">
-        <%= email_inline_image_tag("header/logo-round.svg",
+        <%= email_inline_image_tag("header/logo-round.png",
             class: "logo",
             alt: "ETM Logo") %>
         <h2><%=I18n.t('meta.title')%></h2>


### PR DESCRIPTION
## Description

The ETM logo was not being properly displayed in the emails sent.

The problem seems to come from the fact that SVG is not well-supported as an inline email attachment in most email clients. Gmail has issues with SVG images embedded as CID attachments because it sanitizes HTML heavily for security. Replacing it by a PNG version (since it has the best email client compatibility) should fix the issue, but I'm **not sure how to fully test it locally** as emails are not sent in localhost. It is a very innocuous change so I believe is fine to wait until is merged to beta to test it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes **(in the browser preview, not in the Gmail client)**
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #213
