### PR TITLE
Sync SavedScenario roles to ETEngine on creation

### DIFF
--- a/app/services/api_scenario/set_roles.rb
+++ b/app/services/api_scenario/set_roles.rb
@@ -15,7 +15,7 @@ module ApiScenario::SetRoles
     params = { scenario: {} }
 
     if saved_scenario
-      params[:scenario][:preset_scenario_users] = build_user_params(saved_scenario)
+      params[:scenario][:saved_scenario_users] = build_user_params(saved_scenario)
       params[:scenario][:metadata] = { saved_scenario_id: saved_scenario.id }
     else
       params[:scenario][:set_preset_roles] = true

--- a/app/services/saved_scenario/create.rb
+++ b/app/services/saved_scenario/create.rb
@@ -57,7 +57,7 @@ class SavedScenario::Create
       scenario_id,
       user.id,
       version.tag,
-      [ :protect, :tag_version ],
+      [ :protect, :set_roles, :tag_version ],
       saved_scenario_id: saved_scenario.id
     )
   end

--- a/spec/services/saved_scenario/update_spec.rb
+++ b/spec/services/saved_scenario/update_spec.rb
@@ -18,7 +18,7 @@ describe SavedScenario::Update, type: :service do
       hash_including(
         scenario: hash_including(
           metadata: { saved_scenario_id: saved_scenario.id },
-          preset_scenario_users: kind_of(Array)
+          saved_scenario_users: kind_of(Array)
         )
       )
     )

--- a/spec/services/saved_scenario/upsert_scenario_spec.rb
+++ b/spec/services/saved_scenario/upsert_scenario_spec.rb
@@ -25,7 +25,7 @@ describe SavedScenario::UpsertScenario, type: :service do
       hash_including(
         scenario: hash_including(
           metadata: { saved_scenario_id: old_id },
-          preset_scenario_users: kind_of(Array)
+          saved_scenario_users: kind_of(Array)
         )
       )
     )


### PR DESCRIPTION
## Context
Please see the issue #222.

### Implementation details
I decided to again distinguish between `preset_scenario_roles` and `saved_scenario_users`. 
- `set_preset_roles` acts as a boolean to determine if a session should read and copy the roles set on its preset/parent session.
  - This path exists for scenario forking, and etengine handles this completely
- `saved_scenario_users` is an explicit payload of users to apply to a session in instances of syncing, because the engine is not aware of saved scenario data and making an extra call doesn't make sense.

## Testing callback flow

```
ScenarioUser.create(user_id: 1, scenario_id: 2731032, role_id: 3)
```
> [4] pry(main)> ScenarioUser.create(user_id: 1, scenario_id: 2731032, role_id: 3)
>   TRANSACTION (0.2ms)  BEGIN
>   Scenario Load (0.2ms)  SELECT `scenarios`.* FROM `scenarios` WHERE `scenarios`.`id` = 2731032 LIMIT 1
>   ScenarioUser Create (0.4ms)  INSERT INTO `scenario_users` (`scenario_id`, `role_id`, `user_id`, `user_email`) VALUES (2731032, 3, 1, NULL)
>   TRANSACTION (0.8ms)  COMMIT
> => #<ScenarioUser:0x000000011152d480
>  id: 7288,
>  scenario_id: 2731032,
>  role_id: 3,
>  user_id: 1,
>  user_email: nil>

```
u = ScenarioUser.find(7279)
```
>   ScenarioUser Load (0.6ms)  SELECT `scenario_users`.* FROM `scenario_users` WHERE `scenario_users`.`id` = 7279 LIMIT 1
> => #<ScenarioUser:0x0000000111ae6b88
>  id: 7279,
>  scenario_id: 2731032,
>  role_id: 3,
>  user_id: 2102,
>  user_email: nil>

```
u.destroy
```
>   TRANSACTION (0.2ms)  BEGIN
>   Scenario Load (0.3ms)  SELECT `scenarios`.* FROM `scenarios` WHERE `scenarios`.`id` = 2731032 LIMIT 1
>   ScenarioUser Pluck (1.9ms)  SELECT `scenario_users`.`role_id` FROM `scenario_users` WHERE `scenario_users`.`scenario_id` = 2731032 AND `scenario_users`.`id` != 7279
>   ScenarioUser Destroy (0.6ms)  DELETE FROM `scenario_users` WHERE `scenario_users`.`id` = 7279
>   TRANSACTION (1.1ms)  COMMIT
> => #<ScenarioUser:0x0000000111ae6b88
>  id: 7279,
>  scenario_id: 2731032,
>  role_id: 3,
>  user_id: 2102,
>  user_email: nil>

Now there is only a generic random owner on the Session
<img width="754" height="61" alt="image" src="https://github.com/user-attachments/assets/4cad56f3-4ef5-4732-8809-d40242805898" />

And I am the owner of the saved scenario:
<img width="679" height="242" alt="image" src="https://github.com/user-attachments/assets/fec02ffc-e505-4371-838e-79f8c6b90b4c" />

Now using pyetm update an input using personal non-admin token.

Then:
<img width="640" height="68" alt="image" src="https://github.com/user-attachments/assets/104b74cd-f030-42c5-b6a2-c78993921558" />
(and the update works too 😄)

## Related Issues
See [this Engine Issue](https://github.com/quintel/etengine/issues/1702)
Goes with [this Engine PR](https://github.com/quintel/etengine/pull/1703)

Closes #222 