### PR TITLE
Dump n load instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,11 @@ If you have access to a production or staging MyETM instance:
 
 2. **Navigate to admin section**
    - Click "Admin" in the navigation
-   - Click "Saved Scenarios" in the admin menu
+   - Click "All Scenarios" in the admin menu
    - URL: `https://my.energytransitionmodel.com/admin/saved_scenarios`
 
 3. **Filter for scenarios**
-   - Check "Featured" to show only featured scenarios
+   - Check "Show Featured" to show only featured scenarios
    - Filter by version, end year, or area code as needed
 
 4. **Select scenarios to export**
@@ -218,7 +218,7 @@ If you have access to a production or staging MyETM instance:
    - Or click "Select all" to export all filtered scenarios
 
 5. **Export**
-   - Click the "Export" button
+   - Click the "Export selected" button
    - A `.etm` file will download (format: `YYYYMMDDHHMM_env.etm`)
 
 6. **Save the file**
@@ -363,8 +363,9 @@ Each `.etm` file contains:
 **From ETEngine:**
 - Slider values (user_values)
 - Custom hourly curves
-- Merit order configurations
+- User sortables
 - Area code, end year, privacy settings
+- Balanced values
 
 **From MyETM:**
 - Scenario title and description
@@ -376,9 +377,9 @@ Each `.etm` file contains:
 
 To create a `.etm` file from your local scenarios to share with your team:
 
-1. **Access MyETM admin:** http://localhost:3002/admin/saved_scenarios
+1. **Access MyETM admin:** https://my.energytransitionmodel.com/admin/saved_scenarios
 2. **Select scenarios** you want to export using checkboxes
-3. **Click "Export"** button
+3. **Click "Export selected"** button
 4. **Share the downloaded `.etm` file** with your team
 
 They can then import it using `bin/import-scenarios`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker-compose build
 ```sh
 docker-compose run --rm web bash -c 'chmod +x bin/setup && bin/rails db:drop && bin/setup'
 ```
-⚠️ This command drops any existing database. Use only during initial setup!
+This command drops any existing database. Use only during initial setup!
 
 For updates, install new dependencies using:
 ```sh
@@ -120,3 +120,274 @@ After setting up MyETM, configure it to communicate with ETEngine and ETModel:
 3. Create new applications for **ETEngine (Local)**, **ETModel (Local)** and **Collections (Local)**.
 4. Copy the generated configuration into `config/settings.local.yml` for both ETEngine and ETModel.
    Copy it into `.env.local` for Collections.
+
+---
+
+## Database Setup and Importing Scenarios (Admin Only)
+
+This guide covers setting up your local ETM databases and importing scenarios using the dump-n-load architecture.
+
+**Important:** MyETM must be set up **first** because it's the OAuth provider for ETEngine and ETModel. Follow the steps in order.
+
+### Initial Database Setup
+
+**Note: If using Docker these steps are not necessary**
+
+#### 1. Install and Start MySQL
+
+```bash
+brew install mysql
+brew services start mysql
+```
+
+#### 2. Set Up MyETM Database (FIRST!)
+
+MyETM is the authentication provider for the entire ETM ecosystem, so it must be configured before ETEngine or ETModel.
+
+```bash
+cd myetm
+bundle install
+bin/rails db:prepare
+```
+
+This creates the database, runs migrations, and seeds an admin user. **Save the password displayed in the output:**
+
+```
++------------------------------------------------------------------------------+
+|         Created admin user 'Seeded Admin' with password: aBc123Xy         |
+|           and email: seeded_admin@localdevelopment.com.                   |
++------------------------------------------------------------------------------+
+```
+
+#### 3. Start MyETM
+
+```bash
+bin/dev -p 3002
+# Or: rails s -p 3002
+```
+
+Wait for "Listening on..." before proceeding.
+
+#### 4. Set Up ETEngine Database
+
+```bash
+cd etengine
+bundle install
+bin/rails db:prepare
+```
+
+**Warning:** ETEngine requires ETSource to be cloned in the same parent directory. If you get errors about missing datasets, ensure etsource is cloned alongside etengine.
+
+#### 5. Start ETEngine
+
+```bash
+bin/dev -p 3000
+# Or: rails s -p 3000
+```
+
+**Note:** The first time you create a scenario, ETEngine calculates the base dataset (Netherlands). This takes 5-15 seconds. Be patient!
+
+#### 6. Verify Both Servers Are Running
+
+- MyETM: http://localhost:3002
+- ETEngine: http://localhost:3000
+
+You should be able to access both URLs in your browser.
+
+### Getting .etm Files for Import
+
+To import scenarios, you first need a `.etm` file. There are two ways to get one:
+
+#### Option 1: Export from MyETM Admin Interface (Recommended)
+
+If you have access to a production or staging MyETM instance:
+
+1. **Log in as admin**
+
+2. **Navigate to admin section**
+   - Click "Admin" in the navigation
+   - Click "Saved Scenarios" in the admin menu
+   - URL: `https://my.energytransitionmodel.com/admin/saved_scenarios`
+
+3. **Filter for scenarios**
+   - Check "Featured" to show only featured scenarios
+   - Filter by version, end year, or area code as needed
+
+4. **Select scenarios to export**
+   - Click checkboxes next to desired scenarios
+   - Or click "Select all" to export all filtered scenarios
+
+5. **Export**
+   - Click the "Export" button
+   - A `.etm` file will download (format: `YYYYMMDDHHMM_env.etm`)
+
+6. **Save the file**
+   - File downloads to your Downloads folder by default
+   - Ready to import to your local environment
+
+### Importing Scenarios
+
+With both servers running and a `.etm` file ready:
+
+#### 1. Run the Import Script
+
+```bash
+cd myetm
+bin/import-scenarios
+```
+
+The script will:
+1. Detect any `.etm` file
+2. Warn you that import will modify your database
+3. Prompt for confirmation
+4. Load scenarios via ETEngine API
+5. Create SavedScenario records in MyETM
+6. Display results and ID mappings
+
+#### 2. Verify the Import
+
+Check the output for:
+- Number of scenarios loaded
+- Scenario ID mappings (production ID → local ID)
+- Any warnings about missing data
+
+#### 3. Access Imported Scenarios
+
+- View in MyETM: http://localhost:3002
+- Open in ETModel: http://localhost:3001 (requires ETModel setup)
+
+### Command Options
+
+#### Specify Owner
+
+```bash
+bin/import-scenarios --user your.email@example.com
+```
+
+By default, scenarios are owned by the first admin user.
+
+#### Handle Duplicates
+
+Control what happens when a scenario ID already exists:
+
+```bash
+# Always update existing scenarios (default)
+bin/import-scenarios --on-dup update
+
+# Always create new scenarios
+bin/import-scenarios --on-dup create
+
+# Prompt for each duplicate
+bin/import-scenarios --on-dup prompt
+```
+
+#### Search in Different Directory
+
+```bash
+# Look for .etm files in db/dumps instead of ~/Downloads
+bin/import-scenarios db/dumps
+
+# Or specify exact file path
+bin/import-scenarios /path/to/scenarios.etm
+```
+
+#### Get Full Help
+
+```bash
+bin/import-scenarios --help
+```
+
+### Troubleshooting
+
+#### ETEngine Connection Errors
+
+**Problem:** Import fails with "Connection refused" or timeout errors
+
+**Solution:** Ensure ETEngine is running on port 3000:
+
+```bash
+cd etengine
+bin/dev -p 3000
+# Wait for "Listening on..."
+```
+
+Check that you can access http://localhost:3000 in your browser.
+
+#### MyETM Not Running
+
+**Problem:** Script error: "Database connection failed" or similar
+
+**Solution:** The import-scenarios script runs within MyETM's context. Ensure the database is set up:
+
+```bash
+cd myetm
+bin/rails db:prepare
+```
+
+#### No Admin User
+
+**Problem:** "No users found in database!"
+
+**Solution:** Re-run the seeds:
+
+```bash
+cd myetm
+bin/rails db:seed
+# Save the password displayed!
+# You can then create an account with your own credentials and make yourself an admin if you like!
+```
+
+#### Duplicate Scenario Prompts
+
+**Problem:** Import keeps asking about duplicate scenarios
+
+**Solution:** Use `--on-dup update` to automatically update existing scenarios:
+
+```bash
+bin/import-scenarios --on-dup update ~/Downloads/scenarios.etm
+```
+
+#### File Not Found
+
+**Problem:** "No .etm scenario dump files found"
+
+**Solution:**
+- Ensure the file has a `.etm` extension
+- Check you're looking in the right directory (defaults to `~/Downloads`)
+- Specify the file path directly: `bin/import-scenarios /path/to/file.etm`
+
+### What Gets Imported
+
+Each `.etm` file contains:
+
+**From ETEngine:**
+- Slider values (user_values)
+- Custom hourly curves
+- Merit order configurations
+- Area code, end year, privacy settings
+
+**From MyETM:**
+- Scenario title and description
+- User permissions (owner, collaborators, viewers)
+- Version tags
+- Scenario ID history (tracks origin from production)
+
+### Exporting Scenarios to Share
+
+To create a `.etm` file from your local scenarios to share with your team:
+
+1. **Access MyETM admin:** http://localhost:3002/admin/saved_scenarios
+2. **Select scenarios** you want to export using checkboxes
+3. **Click "Export"** button
+4. **Share the downloaded `.etm` file** with your team
+
+They can then import it using `bin/import-scenarios`.
+
+### Next Steps
+
+After importing scenarios:
+
+1. Access them in MyETM at http://localhost:3002
+2. Set up ETModel to view and modify scenarios in the UI
+3. Use imported scenarios as starting points for development
+4. Export modified scenarios to share with your team

--- a/README.md
+++ b/README.md
@@ -102,15 +102,16 @@ you have to follow these steps to run MyETM.
    2. `cd etsource; bundle install`
 
 6. Create the database you specified in your "database.yml" file, and
-   1. run `bundle exec rake db:setup` to create the tables and add an
+   1. run `bundle exec rake db:prepare` to create the tables and an
       administrator account –– whose name and password will be output at the end –– OR
    2. run `bundle exec rake db:create` to create your database and
       contact the private Quintel slack channel to fill your database with records from staging server
 
-7. You're now ready-to-go! Fire up the Rails process with `rails s -p 3002` or better `bin/dev -p 3002`.
+7. Either way, log in with the auto generated administrator account first! You need to be an admin to set up your applications (see connecting ETEngine, ETModel and Collections below).
 
-8. If you run into an dataset error, check out this
-   [explanation](https://github.com/quintel/etsource#csv-documents "Explanation on etsource CSV files") on CSV files
+8. You're now ready to run MyETM! Fire up the Rails process with `bin/dev -p 3002`.
+
+9. If you run into an dataset error, check out this [explanation](https://github.com/quintel/etsource#csv-documents "Explanation on etsource CSV files") on CSV files
 
 
 ## Connecting to ETEngine, ETModel and Collections
@@ -154,8 +155,8 @@ This creates the database, runs migrations, and seeds an admin user. **Save the 
 
 ```
 +------------------------------------------------------------------------------+
-|         Created admin user 'Seeded Admin' with password: aBc123Xy         |
-|           and email: seeded_admin@localdevelopment.com.                   |
+|         Created admin user 'Seeded Admin' with password: aBc123Xy            |
+|           and email: seeded_admin@localdevelopment.com.                      |
 +------------------------------------------------------------------------------+
 ```
 
@@ -175,6 +176,13 @@ cd etengine
 bundle install
 bin/rails db:prepare
 ```
+
+This creates and initializes **three databases** for ETEngine:
+- `etengine_development` - Main application tables (scenarios, users, etc.)
+- `etengine_queue_development` - Background job processing (Solid Queue)
+- `etengine_cache_development` - Application caching (Solid Cache)
+
+**Note:** `db:prepare` automatically sets up all three databases. You should see a seeded admin user with a password - save this password!
 
 **Warning:** ETEngine requires ETSource to be cloned in the same parent directory. If you get errors about missing datasets, ensure etsource is cloned alongside etengine.
 
@@ -336,6 +344,67 @@ bin/rails db:seed
 # Save the password displayed!
 # You can then create an account with your own credentials and make yourself an admin if you like!
 ```
+
+#### Missing Database Tables
+
+**Problem:** Application fails with errors like "Table 'etengine_development.scenarios' doesn't exist" or "Unknown database" errors.
+
+**Root Causes:**
+- Database setup command was run in the wrong directory
+- Partial/incomplete database setup from a previous attempt
+- Running `db:create` without `db:schema:load` or `db:prepare`
+
+**Solutions:**
+
+1. **Verify you're in the correct application directory:**
+   ```bash
+   pwd  # Should show .../etengine, .../etmodel, or .../myetm
+   ```
+
+2. **Complete fresh database setup:**
+   ```bash
+   # Drop all databases and start fresh
+   bin/rails db:drop:all
+
+   # Create and set up all databases (primary + cache + queue)
+   bin/rails db:prepare
+
+   # Verify tables were created
+   bin/rails runner "puts Scenario.count rescue 'Error: scenarios table missing'"
+   ```
+
+3. **Manual verification (for ETEngine):**
+   ```bash
+   # Check that all 3 databases exist with tables
+   mysql -u root -e "
+   SELECT
+     'PRIMARY' as DB,
+     COUNT(*) as tables
+   FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA='etengine_development'
+   UNION
+   SELECT 'QUEUE', COUNT(*)
+   FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA='etengine_queue_development'
+   UNION
+   SELECT 'CACHE', COUNT(*)
+   FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA='etengine_cache_development';
+   "
+   # Should show: PRIMARY=18, QUEUE=13, CACHE=3
+   ```
+
+**Understanding Multi-Database Architecture:**
+
+ETEngine and ETModel use **multiple databases** per application:
+- **Primary database:** Main application tables (scenarios, users, etc.)
+- **Queue database:** Background job management (Solid Queue)
+- **Cache database:** Application caching (Solid Cache)
+
+The `db:prepare` command automatically sets up ALL databases. If you see errors about missing tables:
+- Check you ran `bundle install` first
+- Ensure MySQL is running: `brew services start mysql`
+- Try the complete fresh setup above
 
 #### Duplicate Scenario Prompts
 

--- a/app/views/admin/saved_scenarios/index.html.haml
+++ b/app/views/admin/saved_scenarios/index.html.haml
@@ -4,6 +4,17 @@
 = render(partial: "block_right_sub_menu", locals: { filters: @filters })
 = render(partial: "admin/block_right_menu")
 
+.bg-blue-50.border-l-4.border-blue-400.p-4.rounded-lg.mb-6
+  %p.text-sm.text-gray-700.mb-2
+    %strong= t('saved_scenarios.dump_load_info.title')
+  %p.text-sm.text-gray-700.mb-2
+    %strong= t('saved_scenarios.dump_load_info.export_label')
+    = t('saved_scenarios.dump_load_info.export_desc')
+  %p.text-sm.text-gray-700.mb-2
+    %strong= t('saved_scenarios.dump_load_info.import_label')
+    = t('saved_scenarios.dump_load_info.import_desc')
+    %code.bg-gray-100.px-2.py-1.rounded.text-xs bin/import-scenarios
+
 - if @saved_scenarios.present?
   = render(partial: "saved_scenarios", locals: {              |
     pagy_admin_saved_scenarios: @pagy_admin_saved_scenarios,  |

--- a/bin/setup
+++ b/bin/setup
@@ -25,6 +25,18 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
+  puts "\n== Verifying database setup =="
+  verify_cmd = <<~BASH
+    mysql -u root -e "SELECT COUNT(*) FROM saved_scenarios LIMIT 1;" my_etm_development 2>&1 > /dev/null
+  BASH
+
+  if system(verify_cmd)
+    puts "✓ Database setup verified successfully"
+  else
+    puts "⚠ Warning: Database may not be fully set up. Tables might be missing."
+    puts "Try running: bin/rails db:drop db:create db:schema:load db:seed"
+  end
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,6 +204,12 @@ en:
     viewers: Viewers
     select_all: Select all
     export: Export selected
+    dump_load_info:
+      title: "Exporting and Importing Scenarios"
+      export_label: "Export:"
+      export_desc: "Select scenarios and click 'Export selected' to create a .etm file."
+      import_label: "Import:"
+      import_desc: "Use the command-line tool to import .etm files from your Downloads folder:"
     filters:
       search: Search by title or user
       clear: Clear filters

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -245,6 +245,12 @@ nl:
     collaborators: Bewerkers
     select_all: Selecteer alles
     export: Geselecteerde exporteren
+    dump_load_info:
+      title: "Scenario's exporteren en importeren"
+      export_label: "Exporteren:"
+      export_desc: "Selecteer scenario's en klik op 'Geselecteerde exporteren' om een .etm-bestand te maken."
+      import_label: "Importeren:"
+      import_desc: "Gebruik de opdrachtregel om .etm-bestanden uit je Downloads-map te importeren:"
     filters:
       search: Zoeken op titel of gebruiker
       clear: Filters wissen


### PR DESCRIPTION
#### Context
Extend myetm readme to cover local database set up and import-scenarios usage.

#### Implemented changes
Extended the readme to outline:
- How to set up a new local db from scratch
- How to use the `bin/import-scenarios` command to import scenarios from beta/pro locally

EDIT:
Goes with:
Goes with [this etengine PR](https://github.com/quintel/etengine/pull/1733)
Goes with [this etmodel PR](https://github.com/quintel/etmodel/pull/4696)

## Checklist

- [~] I have tested these changes (sort of, not from scratch)
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review

The truest way to test this is by turning dbbot off except for ETLocal, and to test the instructions with a new employee who is setting up for the first time. 
Alternatively someone could spend some time dropping all their local dbs and testing the set up from scratch.

@aaccensi I tagged you in case you can spot something I've missed
@mabijkerk I tagged you for functional review - feel free to reassign if you think someone else would be better suited or has more time