### PR TITLE
Change maintainer label in Dockerfile to info@energytransitionmodel.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ARG RUBY_VERSION=4.0.2-slim
 FROM ruby:${RUBY_VERSION} AS base
 
-LABEL maintainer="dev@quintel.com"
+LABEL maintainer="info@energytransitionmodel.com"
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
#### Context
Remove dev@quintel from public facing locations, replace with info@energytransitionmodel.com.

The Dockerfile LABEL is only a metadata field, so this change should have no effect on the container itself.
See: https://docs.docker.com/reference/dockerfile/#label

Goes with pull requests ...
[engine]()
[model]()
[myetm]()
[etlocal]()
[projects]()
[dbbot]()


## Checklist
- [ ] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
