### PR TITLE
Fix contact us form error

### DIFF
--- a/app/mailers/contact_us_mailer.rb
+++ b/app/mailers/contact_us_mailer.rb
@@ -8,8 +8,8 @@ class ContactUsMailer < ActionMailer::Base
     @user_agent = user_agent
 
     mail(
-      to: Settings.feedback_email,
-      from: Settings.feedback_email,
+      to: Settings.mailer.from,
+      from: Settings.mailer.from,
       reply_to: message.email,
       subject: "ETM Feedback"
     )


### PR DESCRIPTION
#### Context

The contact form in MyETM sends an email when a user submits feedback. This forms seems to be broken, not only there are logs lines with `ArgumentError (SMTP From address may not be blank: nil):` but if we test it in the frontend we get a very clear error: <img src="https://uploads.linear.app/865fab38-f05a-4b4c-91f7-800107757197/5724b74f-5117-4dc8-9804-c0e4f3d48ce7/1dca2777-3a88-4ce1-b96c-0d97d071139d?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzg2NWZhYjM4LWYwNWEtNGI0Yy05MWY3LTgwMDEwNzc1NzE5Ny81NzI0Yjc0Zi01MTE3LTRkYzgtOTgwNC1jMGU0ZjNkNDhjZTcvMWRjYTI3NzctM2E4OC00Y2UxLWI5NmMtMGQ5N2QwNzExMzlkIiwiaWF0IjoxNzc4MDc3NzQxLCJleHAiOjE4MDk2NDgzMDF9.bvyuPwpDJ-OZky1e9BteyioQc2lN8kFcBPEZQZW6r1E " alt="image" width="572" data-linear-height="165" />

#### Implemented changes

The mailer was reading the From address from `Settings.feedback_email`, a setting that was never defined in `config/settings.yml`.

This can't be tested well in development because the development environment uses a dummy mail adapter that doesn't validate addresses. In production, the real SMTP server rejected the nil value and raised an ArgumentError.

`config/settings.yml` already has the right setting under a different key (`Settings.mailer.from`), set to "Energy Transition Model [info@energytransitionmodel.com](<mailto:info@energytransitionmodel.com>)". The fix was simply to use that existing key in the mailer instead of the non-existent `Settings.feedback_email`.

#### Related

Closes quintel/my-etm#258

## Checklist

- [ ] I have tested these changes (Cannot test that this works properly locally)
- [ ] I have updated documentation as needed
- [X] I have tagged the relevant people for review