### PR TITLE
Fix NoMethodError on /collections/new when user has no saved scenarios

### DIFF
--- a/app/views/collections/new.html.haml
+++ b/app/views/collections/new.html.haml
@@ -9,13 +9,13 @@
   = f.label :title, t('scenario.title'), class: 'text-sm text-gray-400 mb-2'
   = f.text_field :title, class: 'appearance-none w-1/2 rounded-md border-gray-200 mb-5', placeholder: t('collections.new.form.default_title')
 
-  = f.hidden_field :version, value: @versions.first.tag, data: { collections_target: 'hiddenVersion' }
+  = f.hidden_field :version, value: @versions.first&.tag, data: { collections_target: 'hiddenVersion' }
   - if @versions.count > 1
     = f.label :version, t('collections.new.form.version'), class: 'text-sm text-gray-400 mb-2'
     = select_tag nil,                                                                             |
       options_for_select(@versions.map { |v| [v.titleize, v.tag] }, @versions.first.tag),         |
       data: { action: 'collections#changeVersion', collections_target: 'versionSelect' },         |
-      class: 'appearance-none w-1/2 rounded-md border-gray-200 mb-5'                              | 
+      class: 'appearance-none w-1/2 rounded-md border-gray-200 mb-5'                              |
 
   .mt-5
     .text-sm.text-gray-400{ data: { collections_target: 'sortableListLabel' } }= t('collections.edit.instructions')


### PR DESCRIPTION
#### Context

Users with no available saved scenarios trigger a NoMethodError (undefined method 'tag' for nil) when visiting /collections/new.

Detected via Grafana: first appeared May 20, spiked to 24 occurrences on May 26, all from a single IP. The page was returning HTTP 500 for every request from that session.

#### Implemented changes

Guard `@versions.first` with safe navigator (&.) to prevent a crash when a user has no available saved scenarios and `@versions` is empty.

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
