### PR TITLE
Discard endpoint and spec

### DIFF
--- a/app/controllers/api/v1/saved_scenarios_controller.rb
+++ b/app/controllers/api/v1/saved_scenarios_controller.rb
@@ -75,6 +75,7 @@ module Api
         unless @saved_scenario.discarded?
           @saved_scenario.discarded_at = Time.zone.now
 
+          # Use touch: false to preserve updated_at timestamp.
           unless @saved_scenario.save(touch: false)
             errors = @saved_scenario.errors.full_messages
             errors = [ "Failed to discard scenario" ] if errors.empty?

--- a/app/controllers/api/v1/saved_scenarios_controller.rb
+++ b/app/controllers/api/v1/saved_scenarios_controller.rb
@@ -3,7 +3,7 @@ module Api
     class SavedScenariosController < BaseController
       check_authorization
 
-      load_and_authorize_resource(class: SavedScenario, only: %i[index create show update destroy])
+      load_and_authorize_resource(class: SavedScenario, only: %i[index create show update destroy discard])
 
       # GET /saved_scenarios or /saved_scenarios.json
       def index
@@ -68,6 +68,23 @@ module Api
         else
           render json: { error: "Failed to delete scenario" }, status: :unprocessable_entity
         end
+      end
+
+      # PUT /saved_scenarios/1/discard
+      def discard
+        unless @saved_scenario.discarded?
+          @saved_scenario.discarded_at = Time.zone.now
+
+          unless @saved_scenario.save(touch: false)
+            errors = @saved_scenario.errors.full_messages
+            errors = [ "Failed to discard scenario" ] if errors.empty?
+
+            render json: { errors: errors }, status: :unprocessable_content
+            return
+          end
+        end
+
+        render json: { message: "Scenario discarded successfully" }, status: :ok
       end
 
       private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,6 +5,9 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    # Discard uses the same permissions as destroy (both are owner-only actions)
+    alias_action(:discard, to: :destroy)
+
     can :manage, :all if user&.admin?
 
     can :read, SavedScenario, private: false

--- a/app/models/api/token_ability.rb
+++ b/app/models/api/token_ability.rb
@@ -6,6 +6,9 @@ module Api
     include CanCan::Ability
 
     def initialize(token, user)
+      # Discard uses the same permissions as destroy (both are owner-only actions)
+      alias_action(:discard, to: :destroy)
+
       @scopes = extract_scopes(token)
       @user   = user
 
@@ -79,6 +82,7 @@ module Api
     end
 
     # Allow destroying saved scenarios and collections if the token has the delete scope.
+    # Note: :discard is aliased to :destroy, so destroy permissions apply to discard as well.
     def allow_delete
       if admin?
         can :destroy, SavedScenario

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,10 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :collections, only: %i[index show create update destroy]
       resources :saved_scenarios, only: %i[index show create update destroy] do
+        member do
+          put :discard
+        end
+
         resources :users, only: %i[index create], controller: 'saved_scenario_users' do
           collection do
             put :update

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+RSpec.describe Ability, type: :model do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:admin) { create(:admin) }
+
+  describe 'discard action permissions' do
+    let!(:owned_scenario) do
+      create(:saved_scenario).tap do |scenario|
+        create(:saved_scenario_user,
+               user: user,
+               saved_scenario: scenario,
+               role_id: User::Roles.index_of(:scenario_owner))
+      end
+    end
+
+    let!(:other_scenario) do
+      create(:saved_scenario).tap do |scenario|
+        create(:saved_scenario_user,
+               user: other_user,
+               saved_scenario: scenario,
+               role_id: User::Roles.index_of(:scenario_owner))
+      end
+    end
+
+    # Create ability after scenarios are created
+    subject(:ability) { Ability.new(user) }
+
+    context 'when user is the scenario owner' do
+      it 'allows owner to discard their scenarios' do
+        expect(ability).to be_able_to(:discard, owned_scenario)
+      end
+
+      it 'uses the same permissions as destroy' do
+        expect(ability).to be_able_to(:destroy, owned_scenario)
+        expect(ability).to be_able_to(:discard, owned_scenario)
+      end
+    end
+
+    context 'when user is a collaborator' do
+      let(:collaborator_scenario) do
+        create(:saved_scenario).tap do |scenario|
+          # Create owner first to satisfy the "at least one owner" requirement
+          create(:saved_scenario_user,
+                 user: other_user,
+                 saved_scenario: scenario,
+                 role_id: User::Roles.index_of(:scenario_owner))
+          # Then add user as collaborator
+          create(:saved_scenario_user,
+                 user: user,
+                 saved_scenario: scenario,
+                 role_id: User::Roles.index_of(:scenario_collaborator))
+        end
+      end
+
+      it 'prevents collaborator from discarding scenarios' do
+        expect(ability).not_to be_able_to(:discard, collaborator_scenario)
+      end
+    end
+
+    context 'when user is a viewer' do
+      let(:viewer_scenario) do
+        create(:saved_scenario).tap do |scenario|
+          # Create owner first to satisfy the "at least one owner" requirement
+          create(:saved_scenario_user,
+                 user: other_user,
+                 saved_scenario: scenario,
+                 role_id: User::Roles.index_of(:scenario_owner))
+          # Then add user as viewer
+          create(:saved_scenario_user,
+                 user: user,
+                 saved_scenario: scenario,
+                 role_id: User::Roles.index_of(:scenario_viewer))
+        end
+      end
+
+      it 'prevents viewer from discarding scenarios' do
+        expect(ability).not_to be_able_to(:discard, viewer_scenario)
+      end
+    end
+
+    context 'when user does not own the scenario' do
+      it 'prevents non-owner from discarding scenarios' do
+        expect(ability).not_to be_able_to(:discard, other_scenario)
+      end
+    end
+
+    context 'when user is an admin' do
+      subject(:ability) { Ability.new(admin) }
+
+      it 'allows admin to discard any scenario' do
+        expect(ability).to be_able_to(:discard, other_scenario)
+      end
+
+      it 'allows admin to destroy any scenario' do
+        expect(ability).to be_able_to(:destroy, other_scenario)
+      end
+    end
+  end
+end

--- a/spec/models/api/token_ability_spec.rb
+++ b/spec/models/api/token_ability_spec.rb
@@ -92,6 +92,11 @@ RSpec.describe Api::TokenAbility do
         expect(ability).not_to be_able_to(:destroy, private_saved_scenario)
       end
 
+      it "does not allow discarding any saved scenario" do
+        expect(ability).not_to be_able_to(:discard, public_saved_scenario)
+        expect(ability).not_to be_able_to(:discard, private_saved_scenario)
+      end
+
       it "does not allow destroying any collection" do
         expect(ability).not_to be_able_to(:destroy, user_collection)
       end
@@ -141,6 +146,10 @@ RSpec.describe Api::TokenAbility do
     describe "delete abilities" do
       it "does not allow destroying saved scenarios" do
         expect(ability).not_to be_able_to(:destroy, private_saved_scenario)
+      end
+
+      it "does not allow discarding saved scenarios" do
+        expect(ability).not_to be_able_to(:discard, private_saved_scenario)
       end
     end
   end
@@ -204,6 +213,10 @@ RSpec.describe Api::TokenAbility do
     describe "delete abilities" do
       it "does not allow destroying saved scenarios" do
         expect(ability).not_to be_able_to(:destroy, private_saved_scenario)
+      end
+
+      it "does not allow discarding saved scenarios" do
+        expect(ability).not_to be_able_to(:discard, private_saved_scenario)
       end
     end
   end
@@ -269,10 +282,20 @@ RSpec.describe Api::TokenAbility do
         expect(ability).to be_able_to(:destroy, private_saved_scenario)
       end
 
+      it "allows discarding saved scenarios in owner scope" do
+        expect(ability).to be_able_to(:discard, private_saved_scenario)
+      end
+
       it "does not allow destroying saved scenarios not in owner scope" do
         expect(ability).not_to be_able_to(:destroy, public_saved_scenario)
         expect(ability).not_to be_able_to(:destroy, other_public_saved_scenario)
         expect(ability).not_to be_able_to(:destroy, other_private_saved_scenario)
+      end
+
+      it "does not allow discarding saved scenarios not in owner scope" do
+        expect(ability).not_to be_able_to(:discard, public_saved_scenario)
+        expect(ability).not_to be_able_to(:discard, other_public_saved_scenario)
+        expect(ability).not_to be_able_to(:discard, other_private_saved_scenario)
       end
 
       it "allows destroying collections owned by the user" do
@@ -324,6 +347,13 @@ RSpec.describe Api::TokenAbility do
         expect(ability).to be_able_to(:destroy, private_saved_scenario)
         expect(ability).to be_able_to(:destroy, other_public_saved_scenario)
         expect(ability).to be_able_to(:destroy, other_private_saved_scenario)
+      end
+
+      it "allows discarding all saved scenarios" do
+        expect(ability).to be_able_to(:discard, public_saved_scenario)
+        expect(ability).to be_able_to(:discard, private_saved_scenario)
+        expect(ability).to be_able_to(:discard, other_public_saved_scenario)
+        expect(ability).to be_able_to(:discard, other_private_saved_scenario)
       end
 
       it "allows destroying all collections" do

--- a/spec/requests/api/saved_scenarios_spec.rb
+++ b/spec/requests/api/saved_scenarios_spec.rb
@@ -643,4 +643,125 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       end
     end
   end
+
+  # ------------------------------------------------------------------------------------------------
+
+  describe 'PUT /api/v1/saved_scenarios/:id/discard' do
+    let!(:scenario) { create(:saved_scenario, user:) }
+
+    context 'when the scenario belongs to the user' do
+      let(:request) do
+        put "/api/v1/saved_scenarios/#{scenario.id}/discard",
+          as: :json,
+          headers: access_token_header(user, :delete)
+      end
+
+      it 'returns success' do
+        request
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'sets the discarded_at timestamp' do
+        expect { request }.to change { scenario.reload.discarded_at }.from(nil)
+      end
+
+      it 'does not remove the scenario from the database' do
+        expect { request }.not_to change(SavedScenario, :count)
+      end
+
+      it 'returns a success message' do
+        request
+        expect(JSON.parse(response.body)).to include('message' => 'Scenario discarded successfully')
+      end
+    end
+
+    context 'when discarding an already discarded scenario' do
+      before do
+        scenario.update(discarded_at: 1.day.ago)
+      end
+
+      let(:request) do
+        put "/api/v1/saved_scenarios/#{scenario.id}/discard",
+          as: :json,
+          headers: access_token_header(user, :delete)
+      end
+
+      it 'returns success' do
+        request
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'does not change the discarded_at timestamp' do
+        expect { request }.not_to change { scenario.reload.discarded_at }
+      end
+    end
+
+    context 'when the discard fails with validation errors' do
+      before do
+        allow_any_instance_of(SavedScenario).to receive(:save).and_return(false)
+        allow_any_instance_of(SavedScenario).to receive(:errors).and_return(
+          double(full_messages: ["Title can't be blank"])
+        )
+
+        put "/api/v1/saved_scenarios/#{scenario.id}/discard",
+          as: :json,
+          headers: access_token_header(user, :delete)
+      end
+
+      it 'returns unprocessable entity' do
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'returns validation error messages' do
+        expect(JSON.parse(response.body)).to include('errors' => ["Title can't be blank"])
+      end
+    end
+
+    context 'when the discard fails without specific errors' do
+      before do
+        allow_any_instance_of(SavedScenario).to receive(:save).and_return(false)
+        allow_any_instance_of(SavedScenario).to receive(:errors).and_return(
+          double(full_messages: [])
+        )
+
+        put "/api/v1/saved_scenarios/#{scenario.id}/discard",
+          as: :json,
+          headers: access_token_header(user, :delete)
+      end
+
+      it 'returns unprocessable entity' do
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'returns a fallback error message' do
+        expect(JSON.parse(response.body)).to include('errors' => ['Failed to discard scenario'])
+      end
+    end
+
+    context 'when missing the scenarios:delete scope' do
+      let(:request) do
+        put "/api/v1/saved_scenarios/#{scenario.id}/discard",
+          as: :json,
+          headers: access_token_header(user, :read)
+      end
+
+      it 'returns forbidden' do
+        request
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when the scenario belongs to a different user' do
+      let(:request) do
+        put "/api/v1/saved_scenarios/#{scenario.id}/discard",
+          as: :json,
+          headers: access_token_header(create(:user), :delete)
+      end
+
+      it 'returns forbidden' do
+        request
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/requests/api/saved_scenarios_spec.rb
+++ b/spec/requests/api/saved_scenarios_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'API::SavedScenarios', type: :request, api: true do
+RSpec.describe 'API::SavedScenarios', :api, type: :request do
   let(:user) { create(:user) }
   let(:client) { Faraday.new(url: 'http://testing') }
 
@@ -14,7 +14,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       let!(:user_ss2)    { create(:saved_scenario, user: user) }
       let!(:other_ss)    { create(:saved_scenario, private: true) }
       let!(:public_ss)   { create(:saved_scenario, private: false) }
-      let!(:discarded_ss){ create(:saved_scenario, user: user, discarded_at: 1.day.ago) }
+      let!(:discarded_ss) { create(:saved_scenario, user: user, discarded_at: 1.day.ago) }
 
       before do
         get '/api/v1/saved_scenarios',
@@ -28,7 +28,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
 
       it 'returns only the current user’s saved scenarios' do
         returned_ids = response.parsed_body.map { |s| s['id'] }
-        expect(returned_ids).to match_array([user_ss1.id, user_ss2.id])
+        expect(returned_ids).to contain_exactly(user_ss1.id, user_ss2.id)
       end
 
       it 'does not contain scenarios from other users or public scenarios' do
@@ -123,12 +123,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
 
       it 'includes all scenarios the user is allowed to read (own + any public)' do
         returned_ids = response.parsed_body.map { |s| s['id'] }
-        expect(returned_ids).to match_array([
-          user_private_ss1.id,
-          user_private_ss2.id,
-          user_public_ss.id,
-          other_public_ss.id
-        ])
+        expect(returned_ids).to contain_exactly(user_private_ss1.id, user_private_ss2.id, user_public_ss.id, other_public_ss.id)
       end
 
       it 'excludes private scenarios of other users and any discarded ones' do
@@ -195,7 +190,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
         end
 
         it 'returns an error message' do
-          expect(JSON.parse(response.body)).to eq({ "errors" => ["Not found"] })
+          expect(JSON.parse(response.body)).to eq({ "errors" => [ "Not found" ] })
         end
       end
 
@@ -225,7 +220,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       end
 
       it 'returns an error message' do
-        expect(JSON.parse(response.body)).to eq({ "errors" => ["Saved scenario not found"] })
+        expect(JSON.parse(response.body)).to eq({ "errors" => [ "Saved scenario not found" ] })
       end
     end
 
@@ -254,7 +249,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       end
 
       it 'returns an error message' do
-        expect(JSON.parse(response.body)).to eq({ "errors" => ["Not found"] })
+        expect(JSON.parse(response.body)).to eq({ "errors" => [ "Not found" ] })
       end
     end
   end
@@ -700,7 +695,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       before do
         allow_any_instance_of(SavedScenario).to receive(:save).and_return(false)
         allow_any_instance_of(SavedScenario).to receive(:errors).and_return(
-          double(full_messages: ["Title can't be blank"])
+          double(full_messages: [ "Title can't be blank" ])
         )
 
         put "/api/v1/saved_scenarios/#{scenario.id}/discard",
@@ -713,7 +708,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       end
 
       it 'returns validation error messages' do
-        expect(JSON.parse(response.body)).to include('errors' => ["Title can't be blank"])
+        expect(JSON.parse(response.body)).to include('errors' => [ "Title can't be blank" ])
       end
     end
 
@@ -734,7 +729,7 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       end
 
       it 'returns a fallback error message' do
-        expect(JSON.parse(response.body)).to include('errors' => ['Failed to discard scenario'])
+        expect(JSON.parse(response.body)).to include('errors' => [ 'Failed to discard scenario' ])
       end
     end
 
@@ -761,6 +756,31 @@ RSpec.describe 'API::SavedScenarios', type: :request, api: true do
       it 'returns forbidden' do
         request
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when the user is an admin' do
+      let(:admin) { create(:admin) }
+      let(:other_user_scenario) { create(:saved_scenario, user: create(:user)) }
+
+      let(:request) do
+        put "/api/v1/saved_scenarios/#{other_user_scenario.id}/discard",
+          as: :json,
+          headers: access_token_header(admin, :delete)
+      end
+
+      it 'allows admin to discard any scenario' do
+        request
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'sets the discarded_at timestamp' do
+        expect { request }.to change { other_user_scenario.reload.discarded_at }.from(nil)
+      end
+
+      it 'returns a success message' do
+        request
+        expect(JSON.parse(response.body)).to include('message' => 'Scenario discarded successfully')
       end
     end
   end


### PR DESCRIPTION
#### Context
The saved_scenarios api endpoint only offered a 'destroy' option, not discard. The passthrough from etengine was also accessing this destroy endpoint. There was previously no way to 'discard' via the API.

#### Implemented changes

#### Related
Goes with [this etengine PR](https://github.com/quintel/etengine/pull/1757)

## Checklist

- [x] I have tested these changes
- [] I have updated documentation as needed --> Docs still need updating
- [x] I have tagged the relevant people for review
