### PR TITLE
Prepare for local dev with Docker (ETLauncher)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /tmp/storage/*
 !/tmp/storage/
 !/tmp/storage/.keep
+config/settings.local.yml
 
 /public/assets
 
@@ -40,9 +41,6 @@
 **/.DS_Store
 
 /config/credentials/production.key
-
 /config/credentials/staging.key
-
 /config/credentials/development.key
-
 /config/credentials/test.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,74 +1,32 @@
 # syntax = docker/dockerfile:1
 
-# Base Stage: Ruby and dependencies
+# Development image: single stage, all gem groups (no BUNDLE_WITHOUT), source mounted,
+# assets compiled on the fly. Used by this repo's docker-compose.yml and by ETLauncher /
+# etm-stack via `build.context: ../MyETM`. The deploy build lives in Dockerfile.production.
 ARG RUBY_VERSION=4.0.2-slim
-FROM ruby:${RUBY_VERSION} AS base
+FROM ruby:${RUBY_VERSION}
 
 LABEL maintainer="info@energytransitionmodel.com"
 
-# Set working directory
 WORKDIR /app
 
-# Install required base packages
 RUN apt-get update -yqq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends \
       build-essential \
+      default-libmysqlclient-dev \
       default-mysql-client \
+      git \
+      gnupg \
       libjemalloc2 \
       libvips \
+      libyaml-dev \
       nodejs \
-      git \
-      gnupg && \
-    rm -rf /var/lib/apt/lists /tmp/* /var/tmp/*
-
-# Set environment variables for production
-ENV RAILS_ENV=production \
-    BUNDLE_DEPLOYMENT=1 \
-    BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development:test" \
-    SECRET_KEY_BASE_DUMMY=1
-
-# Throw-away Build Stage: Gems and assets
-FROM base AS build
-
-# Install additional build tools for native extensions
-RUN apt-get update -yqq && \
-    apt-get install --no-install-recommends -y \
-      default-libmysqlclient-dev \
-      git \
       pkg-config && \
-    rm -rf /var/lib/apt/lists /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Copy Gemfile and install dependencies
 COPY Gemfile Gemfile.lock ./
-RUN bundle install && \
-    rm -rf ~/.bundle "${BUNDLE_PATH}/ruby/*/cache" "${BUNDLE_PATH}/ruby/*/bundler/gems/*/.git"
+RUN bundle install
 
-# Copy application code
 COPY . .
 
-# Precompile Rails assets
-RUN bundle exec rails assets:precompile && \
-    bundle exec bootsnap precompile app/ lib/
-
-# Final Stage: Minimal runtime image
-FROM base
-
-# Copy built gems and application from the build stage
-COPY --from=build ${BUNDLE_PATH} ${BUNDLE_PATH}
-COPY --from=build /app /app
-
-# Create a non-root user for runtime
-RUN groupadd --system rails && \
-    useradd --system --gid rails --create-home rails && \
-    chown -R rails:rails /app
-USER rails
-
-# Expose Rails server port
-EXPOSE 3000
-
-# Entrypoint to prepare the database
-ENTRYPOINT ["./bin/docker-entrypoint"]
-
-# Default command to start Rails server
-CMD ["./bin/rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,10 @@ Rails.application.configure do
   # Enable server timing.
   config.server_timing = true
 
+  # Allow the etm-stack cross-app parent domain so the shared etm_sso SSO cookie can be scoped to
+  # a dotted parent the browser accepts
+  config.hosts << ENV.fetch('ETM_HOST_PARENT', '.local.energytransitionmodel.com')
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?


### PR DESCRIPTION
#### Context

my-etm's plain Dockerfile was a production-style build, but it's the one used for local dev (this repo's docker-compose.yml and ETLauncher). That mismatch broke dev workflows and needed fixing separately from Dockerfile.production.

#### Implemented changes

* Rewrote `Dockerfile` as a single-stage dev image: all gem groups installed, source copied in, no asset precompile — mirrors etengine's existing dev/`Dockerfile.production` split.
* Added `config.hosts << ENV.fetch('ETM_HOST_PARENT', '.local.energytransitionmodel.com')` in config/environments/development.rb so requests via myetm.local.energytransitionmodel.com aren't blocked.
* `.gitignore`: added `config/settings.local.yml` (the ETLauncher container-override mount target) and tidied stray blank lines around the credentials-key ignores.

This PR is part of an effort to deploy the ETM locally with docker with ETLauncher :
- my-etm: https://github.com/quintel/my-etm/pull/277 [This one]
- etmodel: https://github.com/quintel/etmodel/pull/4748
- etengine: https://github.com/quintel/etengine/pull/1778
- collections: https://github.com/quintel/multi-year-charts/pull/125

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
