### PR TITLE
Announcement banner

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Admin
+  # Edits the announcement shown in the ETM front-ends.
+  class AnnouncementsController < ApplicationController
+    include AdminController
+
+    before_action :set_announcement
+
+    def edit; end
+
+    def update
+      if @announcement.update(announcement_params)
+        flash[:notice] = t("admin.announcements.success")
+        redirect_to edit_admin_announcement_path
+      else
+        render(:edit, status: :unprocessable_entity)
+      end
+    end
+
+    private
+
+    def set_announcement
+      @announcement = Announcement.editable
+    end
+
+    def announcement_params
+      params.require(:announcement).permit(:active, :body_en, :body_nl)
+    end
+  end
+end

--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class AnnouncementsController < BaseController
+      # GET /api/v1/announcements
+      def index
+        render json: { announcements: Announcement.active.as_json }, status: :ok
+      end
+    end
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# A site-wide message shown in the ETM front-ends, such as a planned maintenance notice.
+#
+# One row is edited through the admin panel. The API serves a collection, so announcements can
+# later be scoped to a single front-end or version without changing how consumers read them.
+class Announcement < ApplicationRecord
+  scope :active, -> { where(active: true) }
+
+  validates :body_en, presence: true, if: :active?
+
+  # The row shown in the admin panel, created on the first visit.
+  def self.editable
+    first || create!
+  end
+
+  def as_json(*)
+    { body_en:, body_nl: }
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -5,9 +5,13 @@
 # One row is edited through the admin panel. The API serves a collection, so announcements can
 # later be scoped to a single front-end or version without changing how consumers read them.
 class Announcement < ApplicationRecord
+  # The banner is a single line in the ETM, and longer messages are shortened with an ellipsis.
+  MAX_LENGTH = 150
+
   scope :active, -> { where(active: true) }
 
   validates :body_en, presence: true, if: :active?
+  validates :body_en, :body_nl, length: { maximum: MAX_LENGTH }
 
   # The row shown in the admin panel, created on the first visit.
   def self.editable

--- a/app/views/admin/_block_right_menu.html.erb
+++ b/app/views/admin/_block_right_menu.html.erb
@@ -18,6 +18,12 @@
     active: controller_name == "featured_scenario_users"
   )) %>
   <%= render(SavedScenarios::NavItem::Component.new(
+    path: edit_admin_announcement_path,
+    title: t('admin.bar.announcements'),
+    icon: "megaphone",
+    active: controller_name == "announcements"
+  )) %>
+  <%= render(SavedScenarios::NavItem::Component.new(
     path: admin_saved_scenarios_path,
     title: t('admin.bar.scenarios'),
     icon: 'adjustments-horizontal',

--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -17,12 +17,13 @@
 
     %div.mb-5
       = f.label :body_en, t('admin.announcements.body_en'), class: 'block text-sm font-medium text-gray-700 mb-1'
-      = f.text_area :body_en, rows: 3, class: 'field w-full'
+      = f.text_area :body_en, rows: 3, maxlength: Announcement::MAX_LENGTH, class: 'field w-full'
 
     %div.mb-5
       = f.label :body_nl, t('admin.announcements.body_nl'), class: 'block text-sm font-medium text-gray-700 mb-1'
-      = f.text_area :body_nl, rows: 3, class: 'field w-full'
+      = f.text_area :body_nl, rows: 3, maxlength: Announcement::MAX_LENGTH, class: 'field w-full'
 
+    %p.text-sm.text-gray-500.mb-1= t('admin.announcements.length', count: Announcement::MAX_LENGTH)
     %p.text-sm.text-gray-500.mb-5= t('admin.announcements.delay')
 
     = button_tag t('admin.announcements.submit'), class: button_classes('text-base', size: :lg, color: :success)

--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -1,0 +1,28 @@
+- content_for :menu_title, t('admin.announcements.title')
+- content_for :title, t('admin.announcements.title')
+= render partial: '/admin/block_right_menu'
+
+%div.max-w-2xl
+  %p.text-sm.text-gray-700.mb-6= t('admin.announcements.intro')
+
+  - if @announcement.errors.any?
+    %ul.text-sm.text-red-600.list-disc.ml-5.mb-5
+      - @announcement.errors.full_messages.each do |message|
+        %li= message
+
+  = form_for @announcement, url: admin_announcement_path, html: { method: :put } do |f|
+    %label.flex.items-center.gap-2.text-sm.font-medium.text-gray-700.mb-5
+      = f.check_box :active, class: 'rounded border-gray-300'
+      = t('admin.announcements.active')
+
+    %div.mb-5
+      = f.label :body_en, t('admin.announcements.body_en'), class: 'block text-sm font-medium text-gray-700 mb-1'
+      = f.text_area :body_en, rows: 3, class: 'field w-full'
+
+    %div.mb-5
+      = f.label :body_nl, t('admin.announcements.body_nl'), class: 'block text-sm font-medium text-gray-700 mb-1'
+      = f.text_area :body_nl, rows: 3, class: 'field w-full'
+
+    %p.text-sm.text-gray-500.mb-5= t('admin.announcements.delay')
+
+    = button_tag t('admin.announcements.submit'), class: button_classes('text-base', size: :lg, color: :success)

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -16,6 +16,7 @@ en:
       active: Show this announcement
       body_en: Message (English)
       body_nl: Message (Dutch)
+      length: The banner is a single line, so keep the message under %{count} characters.
       delay: It can take up to five minutes before a change appears in the ETM.
       submit: Update
       success: The announcement was updated!

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -7,6 +7,18 @@ en:
       collections: All collections
       applications: Local ETM & applications
       featured_users: Featured users
+      announcements: Announcement
+    announcements:
+      title: Announcement
+      intro: >
+        Shows a message at the top of every page in the ETM. Use it for planned maintenance or
+        other short notices.
+      active: Show this announcement
+      body_en: Message (English)
+      body_nl: Message (Dutch)
+      delay: It can take up to five minutes before a change appears in the ETM.
+      submit: Update
+      success: The announcement was updated!
     users:
       confirm: Confirm
       edit:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -7,6 +7,18 @@ nl:
       collections: Alle collecties
       applications: ETM lokaal & applicaties
       featured_users: Uitgelichte gebruikers
+      announcements: Mededeling
+    announcements:
+      title: Mededeling
+      intro: >
+        Toont een bericht bovenaan elke pagina in de ETM. Gebruik dit voor gepland onderhoud of
+        andere korte mededelingen.
+      active: Toon deze mededeling
+      body_en: Bericht (Engels)
+      body_nl: Bericht (Nederlands)
+      delay: Het kan tot vijf minuten duren voordat een wijziging in de ETM zichtbaar is.
+      submit: Bijwerken
+      success: De mededeling is bijgewerkt!
     users:
       confirm: Bevestig
       edit:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -16,6 +16,7 @@ nl:
       active: Toon deze mededeling
       body_en: Bericht (Engels)
       body_nl: Bericht (Nederlands)
+      length: De banner is één regel, houd het bericht daarom korter dan %{count} tekens.
       delay: Het kan tot vijf minuten duren voordat een wijziging in de ETM zichtbaar is.
       submit: Bijwerken
       success: De mededeling is bijgewerkt!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
         collection { get :scenarios }
       end
       resources :versions, only: [:index]
+      resources :announcements, only: [:index]
     end
   end
 
@@ -141,6 +142,8 @@ Rails.application.routes.draw do
     end
 
     resources :featured_scenario_users
+
+    resource :announcement, only: %i[edit update]
 
     resources :saved_scenarios, only: [:index] do
       collection do

--- a/db/migrate/20260805120000_create_announcements.rb
+++ b/db/migrate/20260805120000_create_announcements.rb
@@ -1,0 +1,11 @@
+class CreateAnnouncements < ActiveRecord::Migration[8.1]
+  def change
+    create_table :announcements do |t|
+      t.boolean :active, null: false, default: false
+      t.text :body_en
+      t.text :body_nl
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_21_085203) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_05_120000) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -47,6 +47,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_21_085203) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.boolean "active", default: false, null: false
+    t.text "body_en"
+    t.text "body_nl"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "collection_saved_scenarios", primary_key: ["collection_id", "saved_scenario_id"], charset: "utf8mb3", force: :cascade do |t|

--- a/spec/requests/admin/announcements_spec.rb
+++ b/spec/requests/admin/announcements_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/admin/announcement', type: :request do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'GET /admin/announcement/edit' do
+    it 'is not found for non-admins' do
+      sign_in(user)
+      get '/admin/announcement/edit'
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'creates the announcement switched off on the first visit' do
+      sign_in(admin)
+      get '/admin/announcement/edit'
+
+      expect(response).to have_http_status(:ok)
+      expect(Announcement.sole).to have_attributes(active: false, body_en: nil, body_nl: nil)
+    end
+  end
+
+  describe 'PUT /admin/announcement' do
+    it 'updates the announcement' do
+      sign_in(admin)
+
+      put '/admin/announcement', params: {
+        announcement: { active: '1', body_en: 'Maintenance', body_nl: 'Onderhoud' }
+      }
+
+      expect(response).to redirect_to(edit_admin_announcement_path)
+      expect(Announcement.active.sole.body_en).to eq('Maintenance')
+    end
+  end
+end

--- a/spec/requests/api/announcements_spec.rb
+++ b/spec/requests/api/announcements_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Announcements API', type: :request do
+  describe 'GET /api/v1/announcements' do
+    before do
+      Announcement.create!(active: true, body_en: 'Maintenance', body_nl: 'Onderhoud')
+      Announcement.create!(active: false, body_en: 'Not shown')
+
+      get '/api/v1/announcements', as: :json
+    end
+
+    it 'returns the active announcements without requiring a token' do
+      expect(response).to have_http_status(:ok)
+
+      expect(JSON.parse(response.body)['announcements']).to eq(
+        [{ 'body_en' => 'Maintenance', 'body_nl' => 'Onderhoud' }]
+      )
+    end
+  end
+end


### PR DESCRIPTION
#### Context

When making infrastructure changes to the server or any other kind of maintenance we did not have a way to announce this, therefore the intention is to add a simple way to enable/disable a banner and change the text at any given time without having to cherry pick commits.

#### Implemented changes

**Data**
- `db/migrate/20260805120000_create_announcements.rb` — `announcements` table: `active` (default `false`), `body_en`, `body_nl`
- `app/models/announcement.rb` — `active` scope, `body_en` required when active, `.editable` returns/creates the single row

**Admin** (`/admin/announcement/edit`)
- `app/controllers/admin/announcements_controller.rb` — singleton edit/update, guarded by the existing `AdminController` concern
- `app/views/admin/announcements/edit.html.haml` — on/off checkbox + both message fields
- `app/views/admin/_block_right_menu.html.erb` — sidebar entry
- `config/locales/admin.{en,nl}.yml` — admin copy

**API**
- `app/controllers/api/v1/announcements_controller.rb` — `GET /api/v1/announcements`, unauthenticated, active only
- `config/routes.rb` — both routes

**Specs**
- `spec/requests/api/announcements_spec.rb` — active returned, inactive filtered, no token needed
- `spec/requests/admin/announcements_spec.rb` — non-admins 404, first visit creates the row switched off, admins can update

#### Related

- etmodel: https://github.com/quintel/etmodel/pull/4770
- my-etm: https://github.com/quintel/my-etm/pull/289 [This one]


## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
